### PR TITLE
Clean up formats in quick-tour topics folder

### DIFF
--- a/src/quick-tour/attract-customers.md
+++ b/src/quick-tour/attract-customers.md
@@ -4,18 +4,17 @@ title: Attract New Customers
 
 Magento is packed with features that make it easy to create a “search engine friendly” websites and increase the likelihood of bringing the right customers to your site.
 
-[Search Engine Optimization]({{ site.baseurl }}{% link marketing/seo-search.md %})
-:  Magento offers powerful, native capabilities to streamline Search Engine Optimization (SEO) practices for content and site exposure that are integrated with the Admin, and tied directly into the user experience.
+Search Engine Optimization
+:  Magento offers powerful, native capabilities to streamline [Search Engine Optimization (SEO)]({{ site.baseurl }}{% link marketing/seo-search.md %}) practices for content and site exposure that are integrated with the Admin, and tied directly into the user experience.
 
-[Custom URLs]({{ site.baseurl }}{% link stores/store-urls.md %})
-:  Custom URLs are short, clean, and easy to remember. You can also autogenerate search-friendly URLs to streamline your purchase path.
+Custom URLs
+:  Specify [custom URLs]({{ site.baseurl }}{% link stores/store-urls.md %}) to make them short, clean, and easy to remember. You can also autogenerate search-friendly URLs to streamline your purchase path.
 
-[Meta Data]({{ site.baseurl }}{% link marketing/meta-data.md %})
-:  Improve your search engine rankings by choosing specific criteria that helps search engines to find and index your products more easily. Meta data can be entered for product, category, and content pages.
+Meta Data
+:  Improve your search engine rankings by choosing specific criteria that helps search engines to find and index your products more easily. You can enter [meta data]({{ site.baseurl }}{% link marketing/meta-data.md %}) for product, category, and content pages.
 
-[Sitemap]({{ site.baseurl }}{% link marketing/sitemap-xml.md %})
-:  Link to a sitemap from the footer of your store to give customers an overview of the catalog structure, with links to all categories and products in the store. Easy integration with Google Sitemap.
+Sitemap
+:  Link to a [sitemap]({{ site.baseurl }}{% link marketing/sitemap-xml.md %}) from the footer of your store to give customers an overview of the catalog structure, with links to all categories and products in the store. Easy integration with Google Sitemap.
 
-[Analytics]({{ site.baseurl }}{% link marketing/google-universal-analytics.md %})
-:  In addition to monitoring your site from the Admin dashboard, you can integrate third-party analytics tools such as Google Analytics<!--{% if "Default.EE-B2B" contains site.edition %}--> and [New Relic Reporting]({{ site.baseurl }}{% link reports/new-relic-reporting.md %})
-<!--{% endif %}--> for detailed statistics on traffic and sales.
+Analytics
+:  In addition to monitoring your site from the Admin dashboard, you can integrate third-party analytics tools such as [Google Analytics]({{ site.baseurl }}{% link marketing/google-universal-analytics.md %})<!--{% if "Default.EE-B2B" contains site.edition %}--> and [New Relic Reporting]({{ site.baseurl }}{% link reports/new-relic-reporting.md %})<!--{% endif %}--> for detailed statistics on traffic and sales.

--- a/src/quick-tour/build-loyalty.md
+++ b/src/quick-tour/build-loyalty.md
@@ -3,20 +3,20 @@ conditions: Default.B2B Only
 title: Build Loyalty
 ---
 
-[Friction-Free Purchasing]({{ site.baseurl }}{% link customers/account-dashboard.md %})
-:  Magento’s self-service model makes it easy to build loyalty for fast, friction-free purchasing.
+Friction-Free Purchasing
+:  Magento’s self-service model makes it easy to build loyalty for fast, [friction-free purchasing]({{ site.baseurl }}{% link customers/account-dashboard.md %}).
 
-[Fast Reordering]({{ site.baseurl }}{% link customers/account-dashboard-my-orders.md %})
-:  Create new orders based on previous orders from the convenience of your customer account.
+Fast Reordering
+:  CUstomers can create new orders based on [previous orders]({{ site.baseurl }}{% link customers/account-dashboard-my-orders.md %}) from the convenience of their customer account.
 
-[Order by SKU]({{ site.baseurl }}{% link sales/order-by-sku.md %})
-:  Add individual products to your cart by SKU and quantity, or import a list of products from a file.
+Order by SKU
+:  Customers can add individual products to their cart [by SKU]({{ site.baseurl }}{% link sales/order-by-sku.md %}) and quantity or import a list of products from a file.
 
-[Request a Quote]({{ site.baseurl }}{% link sales/quote-request.md %})
-:  Authorized company buyers can initiate a price negotiation by requesting a quote from the shopping cart.
+Request a Quote
+:  Authorized company buyers can initiate a price negotiation by [requesting a quote]({{ site.baseurl }}{% link sales/quote-request.md %}) from the shopping cart.
 
-[Punch Out Solutions][1]
-:  Establish new customers with third-party solutions such as [Punch Out Catalogs][2] and [PunchOut2Go][3]{: target="_blank"}.
+Punch Out Solutions
+:  Establish new customers with third-party solutions, such as [Punch Out Catalogs][2] and [PunchOut2Go][3]. You can find these solutions on the [Magento Marketplace][1]{: target="_blank"}.
 
 [1]: https://marketplace.magento.com/
 [2]: https://www.punchoutcatalogs.com/

--- a/src/quick-tour/catalog-page.md
+++ b/src/quick-tour/catalog-page.md
@@ -6,5 +6,5 @@ Catalog page listings typically have small product images and brief descriptions
 
 The initial product description usually gives shoppers just enough information to merit a closer look. People who know what they want can add the product to their carts and go. Customers who shop while logged in to their accounts enjoy a personalized shopping experience.
 
-![]({{ site.baseurl }}{% link images/images/storefront-collection-page.png %}){: .zoom}
-*Catalog Page*
+![Collection page on the storefront]({{ site.baseurl }}{% link images/images/storefront-collection-page.png %}){: .zoom}
+_Catalog Page_

--- a/src/quick-tour/customer-journey.md
+++ b/src/quick-tour/customer-journey.md
@@ -2,26 +2,20 @@
 title: Customer Journey
 ---
 
-## Attract New Customers
+Attract New Customers
+:  Magento includes Search Engine Optimization (SEO) functionality out of the box. Improve your search ranking and [attract]({{ site.baseurl }}{% link quick-tour/attract-customers.md %}) the most visitors to your site.
 
-Magento includes SEO functionality out of the box. Improve your search ranking and [attract]({{ site.baseurl }}{% link quick-tour/attract-customers.md %}) the most visitors to your site.
+Engage Your Customers
+:  Design your site with prepared templates, or create a custom design with features that [invite]({{ site.baseurl }}{% link quick-tour/engage.md %}) people to interact with your store.
 
-## Engage Your Customers
+Increase AOV
+:  [Increase average order value]({{ site.baseurl }}{% link quick-tour/increase-average-order-value.md %}) with promotions and content that encourage your customers to shop more.
 
-Design your site with prepared templates, or create a custom design with features that [invite]({{ site.baseurl }}{% link quick-tour/engage.md %}) people to interact with your store.
+Moment of Purchase
+:  Give your customers a [faster and easier way to check out]({{ site.baseurl }}{% link quick-tour/moment-of-purchase.md %}). Calculate shipping and taxes automatically, and integrate multiple payment methods on a single page.
 
-## Increase AOV
+Customer Retention
+:  Create and manage [newsletters and promotions]({{ site.baseurl }}{% link quick-tour/customer-retention.md %}) to keep your customers coming back for more.
 
-[Increase average order value]({{ site.baseurl }}{% link quick-tour/increase-average-order-value.md %}) with promotions and content that encourage your customers to shop more.
-
-## Moment of Purchase
-
-Give your customers a [faster and easier way to check out]]({{ site.baseurl }}{% link quick-tour/moment-of-purchase.md %}). Calculate shipping and taxes automatically, and integrate multiple payment methods on a single page.
-
-## Customer Retention
-
-Create and manage [newsletters and promotions]({{ site.baseurl }}{% link quick-tour/customer-retention.md %}) to keep your customers coming back for more.
-
-## Loyalty and Advocacy
-
-[Encourage customers]({{ site.baseurl }}{% link quick-tour/loyalty-advocacy.md %}) to write product reviews, create wish lists, and send email about products to their friends. Strengthen your relationship with your customers, who in return, speak positively of your business to friends and family.
+Loyalty and Advocacy
+:  [Encourage customers]({{ site.baseurl }}{% link quick-tour/loyalty-advocacy.md %}) to write product reviews, create wish lists, and send email about products to their friends. Strengthen your relationship with your customers, who in return, speak positively of your business to friends and family.

--- a/src/quick-tour/customer-retention.md
+++ b/src/quick-tour/customer-retention.md
@@ -4,31 +4,30 @@ title: Retain Customers
 
 Magento makes it easy for you to get repeat business and build brand loyalty. Magento gives you total control and flexibility over creating and revising goodies like rewards programs, custom coupons and automated emails to keep your customers coming back again and again.
 
-[Email Marketing Automation]({{ site.baseurl }}{% link marketing/engagement-cloud.md %})
-:  Send professionally designed, dynamic email campaigns with with live data from your Magento store, powered by [dotdigital][1]{: target="_blank"}
+Email Marketing Automation
+:  Send professionally designed, dynamic [email campaigns]({{ site.baseurl }}{% link marketing/engagement-cloud.md %}) with live data from your Magento store, powered by [dotdigital][1].
 
 <!--{% if "Default.EE-B2B" contains site.edition %}-->
-[RMA]({{ site.baseurl }}{% link sales/returns.md %})
-:  Customers can submit requests for Return Merchandise Authorization from your store. You can create shipment orders in a carrier system, and print shipping labels with RMA numbers.
+Merchandise Return
+:  Customers can submit requests for [Return Merchandise Authorization]({{ site.baseurl }}{% link sales/returns.md %}) from your store. You can create shipment orders in a carrier system, and print shipping labels with RMA numbers.
 
-[Store Credit]({{ site.baseurl }}{% link sales/store-credit-using.md %})
-:  Keep customers loyal and happy by issuing refunds as store credit or virtual gift cards to ensure that the money they spend stays in your store.
+Store Credit
+:  Keep customers loyal and happy by issuing refunds as [store credit]({{ site.baseurl }}{% link sales/store-credit-using.md %}) or virtual gift cards to ensure that the money they spend stays in your store.
 
-[Reward Points]({{ site.baseurl }}{% link marketing/rewards-loyalty.md %})
-:  Drive customer engagement with reward programs with award points based on a range of transactions and customer behaviors. Base redemption on a variety of factors, such as balance, customer history, and conversion rates.
+Reward Points
+:  Drive customer engagement with [reward programs and points]({{ site.baseurl }}{% link marketing/rewards-loyalty.md %}) based on a range of transactions and customer behaviors. Base redemption on a variety of factors, such as balance, customer history, and conversion rates.
 
-[Target Shopping History]({{ site.baseurl }}{% link marketing/customer-segments.md %})
-:  Encourage customers to make return purchases with targeted promotions based on their shopping history. With the Magento platform, you can easily build segments based on your customer base.
+Target Shopping History
+:  Encourage customers to make return purchases with targeted promotions based on their shopping history. With Magento Commerce, you can easily [build segments]({{ site.baseurl }}{% link marketing/customer-segments.md %}) based on your customer base.
 <!--{% endif %}-->
 
-[Custom Coupons]({{ site.baseurl }}{% link marketing/price-rules-cart-coupon.md %})
-:  Create coupons codes for social media, email, or print campaigns. You can incorporate coupon codes into any design you like.
+Custom Coupons
+:  [Create coupons codes]({{ site.baseurl }}{% link marketing/price-rules-cart-coupon.md %}) for social media, email, or print campaigns. You can incorporate coupon codes into any design you like.
 
+Newsletters
+:  Stay in touch with current customers who’ve opted to receive [newsletters]({{ site.baseurl }}{% link marketing/newsletters.md %}). You can create as many newsletter templates as you want.
 
-[Newsletters]({{ site.baseurl }}{% link marketing/newsletters.md %})
-:  Stay in touch with current customers who’ve opted to receive newsletters. You can create as many newsletter templates as you want.
-
-[RSS Feed]({{ site.baseurl }}{% link marketing/rss-feed.md %})
-:  When RSS feeds are enabled, any additions to products, specials, categories, and coupons are automatically sent to the subscribers of each feed. A link to all RSS feeds that you publish is in the footer of your store.
+RSS Feed
+:  When [RSS feeds]({{ site.baseurl }}{% link marketing/rss-feed.md %}) are enabled, subscribers of each feed automatically receive alerts about any additions to products, specials, categories, and coupons. A link to all RSS feeds that you publish is provided in the footer of your store.
 
 [1]: https://dotdigital.com/

--- a/src/quick-tour/customer-retention.md
+++ b/src/quick-tour/customer-retention.md
@@ -9,7 +9,7 @@ Email Marketing Automation
 
 <!--{% if "Default.EE-B2B" contains site.edition %}-->
 Merchandise Return
-:  Customers can submit requests for [Return Merchandise Authorization]({{ site.baseurl }}{% link sales/returns.md %}) from your store. You can create shipment orders in a carrier system, and print shipping labels with RMA numbers.
+:  Customers can submit requests for [Return Merchandise Authorization]({{ site.baseurl }}{% link sales/returns.md %}) from your store. You can create shipment orders in a carrier system and print shipping labels with RMA numbers.
 
 Store Credit
 :  Keep customers loyal and happy by issuing refunds as [store credit]({{ site.baseurl }}{% link sales/store-credit-using.md %}) or virtual gift cards to ensure that the money they spend stays in your store.

--- a/src/quick-tour/differentiate-personalize.md
+++ b/src/quick-tour/differentiate-personalize.md
@@ -19,4 +19,4 @@ Customer Groups
 :  Offer different products and pricing according to [customer group]({{ site.baseurl }}{% link customers/customer-groups.md %}) or [shared catalog]({{ site.baseurl }}{% link catalog/catalog-shared.md %}). Determine which discounts are available and the tax class that applies to the order.
 
 Maintain Multiple Tailored Websites
-:  Maintain [multiple tailored sites]({{ site.baseurl }}{% link stores/websites-stores-views.md %}) based on brand, geography, channel partner, or account. Introduce new market and languages, and track analytics from a single Admin.
+:  Maintain [multiple tailored sites]({{ site.baseurl }}{% link stores/websites-stores-views.md %}) based on brand, geography, channel partner, or account. Introduce new markets and languages, and track the analytics from a single Admin.

--- a/src/quick-tour/differentiate-personalize.md
+++ b/src/quick-tour/differentiate-personalize.md
@@ -3,20 +3,20 @@ conditions: Default.B2B Only
 title: Differentiate and Personalize
 ---
 
-[Create Custom Experiences]({{ site.baseurl }}{% link quick-tour/engage.md %})
-:  Magento offers a rich set of tools to create personalized experiences across multiple digital touchpoints, based on customer activity and profile.
+Create Custom Experiences
+:  Magento offers a rich set of tools to create [personalized experiences]({{ site.baseurl }}{% link quick-tour/engage.md %}) across multiple digital touchpoints, based on customer activity and profile.
 
-[Custom Catalog and Price Lists]({{ site.baseurl }}{% link catalog/catalog-shared-pricing-structure.md %})
-:  Offer a curated product selection with custom pricing for specific companies, while continuing to offer the standard catalog with regular pricing for general customers.
+Custom Catalog and Price Lists
+:  Offer a curated product selection with custom [pricing for specific companies]({{ site.baseurl }}{% link catalog/catalog-shared-pricing-structure.md %}), while continuing to offer the standard catalog with regular pricing for general customers.
 
-[Targeted Segmentation]({{ site.baseurl }}{% link marketing/customer-segments.md %})
-:  Optimize your marketing initiatives with dynamic content, promotions, and banner based on properties such as customer address, order history, and shopping cart contents.
+Targeted Segmentation
+:  Optimize your marketing initiatives with dynamic content, promotions, and banner [based on properties]({{ site.baseurl }}{% link marketing/customer-segments.md %}) such as customer address, order history, and shopping cart contents.
 
-[Smart Shopping Rules]({{ site.baseurl }}{% link marketing/promotions.md %})
-:  Customize the shopping experience with price rules and promotions that trigger at the product or shopping cart level.
+Smart Shopping Rules
+:  Customize the shopping experience with price rules and [promotions]({{ site.baseurl }}{% link marketing/promotions.md %}) that trigger at the product or shopping cart level.
 
-[Customer Groups]({{ site.baseurl }}{% link customers/customer-groups.md %})
-:  Offer different products and pricing according to customer group or [shared catalog]({{ site.baseurl }}{% link catalog/catalog-shared.md %}). Determine which discounts are available, and the tax class that applies to the order.
+Customer Groups
+:  Offer different products and pricing according to [customer group]({{ site.baseurl }}{% link customers/customer-groups.md %}) or [shared catalog]({{ site.baseurl }}{% link catalog/catalog-shared.md %}). Determine which discounts are available, and the tax class that applies to the order.
 
-[Maintain Multiple Tailored Websites]({{ site.baseurl }}{% link stores/websites-stores-views.md %})
-:  Maintain multiple tailored sites based on brand, geography, channel partner, or account. Introduce new market and languages, and track analytics from a single Admin.
+Maintain Multiple Tailored Websites
+:  Maintain [multiple tailored sites]({{ site.baseurl }}{% link stores/websites-stores-views.md %}) based on brand, geography, channel partner, or account. Introduce new market and languages, and track analytics from a single Admin.

--- a/src/quick-tour/differentiate-personalize.md
+++ b/src/quick-tour/differentiate-personalize.md
@@ -16,7 +16,7 @@ Smart Shopping Rules
 :  Customize the shopping experience with price rules and [promotions]({{ site.baseurl }}{% link marketing/promotions.md %}) that trigger at the product or shopping cart level.
 
 Customer Groups
-:  Offer different products and pricing according to [customer group]({{ site.baseurl }}{% link customers/customer-groups.md %}) or [shared catalog]({{ site.baseurl }}{% link catalog/catalog-shared.md %}). Determine which discounts are available, and the tax class that applies to the order.
+:  Offer different products and pricing according to [customer group]({{ site.baseurl }}{% link customers/customer-groups.md %}) or [shared catalog]({{ site.baseurl }}{% link catalog/catalog-shared.md %}). Determine which discounts are available and the tax class that applies to the order.
 
 Maintain Multiple Tailored Websites
 :  Maintain [multiple tailored sites]({{ site.baseurl }}{% link stores/websites-stores-views.md %}) based on brand, geography, channel partner, or account. Introduce new market and languages, and track analytics from a single Admin.

--- a/src/quick-tour/engage.md
+++ b/src/quick-tour/engage.md
@@ -9,7 +9,7 @@ Content Management
 :  Magento’s [Page Builder]({{ site.baseurl }}{% link cms/page-builder.md %}) makes it easy to create [targeted pages]({{ site.baseurl }}{% link cms/page-builder-add-dynamic-block.md %}) with [interactive elements]({{ site.baseurl }}{% link cms/page-builder-elements-buttons.md %}) that engage your customers. Even those without a technology background can create and manage content.
 <!--{% endif %}-->
 <!--{% if "Default.CE Only" contains site.edition %}-->
-:  Magento’s [CMS]({{ site.baseurl }}{% link cms/content-menu.md %}) makes it easy to store pages, or parts of pages, that you can use in your store. Even those without a technology background can create and manage site content.
+:  Magento’s [CMS]({{ site.baseurl }}{% link cms/content-menu.md %}) makes it easy to store pages, or parts of pages, that you can use in your store. Even users without a technology background can create and manage site content.
 <!--{% endif %}-->
 
 Design and Theme

--- a/src/quick-tour/engage.md
+++ b/src/quick-tour/engage.md
@@ -4,25 +4,25 @@ title: Engage Your Customers
 
 Magento makes it easy to create a customized, engaging site experience. Encourage your customers to spend more time exploring your site, and give them the tools to make it easy to find what they want faster.
 
-[Content Management]({{ site.baseurl }}{% link cms/content-menu.md %})
+Content Management
 <!--{% if "Default.EE-B2B" contains site.edition %}-->
 :  Magento’s [Page Builder]({{ site.baseurl }}{% link cms/page-builder.md %}) makes it easy to create [targeted pages]({{ site.baseurl }}{% link cms/page-builder-add-dynamic-block.md %}) with [interactive elements]({{ site.baseurl }}{% link cms/page-builder-elements-buttons.md %}) that engage your customers. Even those without a technology background can create and manage content.
 <!--{% endif %}-->
 <!--{% if "Default.CE Only" contains site.edition %}-->
-:  Magento’s CMS makes it easy to store pages, or parts of pages, that you can use in your store. Even those without a technology background can create and manage site content.
+:  Magento’s [CMS]({{ site.baseurl }}{% link cms/content-menu.md %}) makes it easy to store pages, or parts of pages, that you can use in your store. Even those without a technology background can create and manage site content.
 <!--{% endif %}-->
 
-[Design &amp; Theme]({{ site.baseurl }}{% link design/design-menu.md %})
-:  Control the visual elements of your store with a collection of templates and skin files. You can apply these visual elements to all pages in your store, giving your store a cohesive look and feel.
+Design and Theme
+:  Control the [visual elements]({{ site.baseurl }}{% link design/design-menu.md %}) of your store with a collection of templates and skin files. You can apply these visual elements to all pages in your store, giving your store a cohesive look and feel.
 
-[Multiple Stores, Sites &amp; Views]({{ site.baseurl }}{% link stores/websites-stores-views.md %})
-:  Control the look and feel of multiple sites, introduce new market and languages, and track analytics from a single Admin.
+Multiple Stores, Sites, and Views
+:  Control the look and feel of [multiple sites]({{ site.baseurl }}{% link stores/websites-stores-views.md %}), introduce new market and languages, and track analytics from a single Admin.
 
-[Multiple Devices]({{ site.baseurl }}{% link design/themes.md %})
-:  Magento’s powerful features make it easy to create storefronts optimized for iPhone, Android, and Mobile Opera browsers to help you engage consumers with mobile commerce now, and into the future.
+Multiple Devices
+:  Magento’s powerful features make it easy to [create storefronts]({{ site.baseurl }}{% link design/themes.md %}) optimized for iPhone, Android, and Mobile Opera browsers to help you engage consumers with mobile commerce now, and into the future.
 
-[Shopping Tools]({{ site.baseurl }}{% link marketing/shopping-tools.md %})
-:  Your store includes a set of shopping tools that create opportunities for your customers to interact with your store, connect on social media, and share with friends.
+Shopping Tools
+:  Your store includes a set of [shopping tools]({{ site.baseurl }}{% link marketing/shopping-tools.md %}) that create opportunities for your customers to interact with your store, connect on social media, and share with friends.
 
-[Sophisticated Search]({{ site.baseurl }}{% link marketing/seo-search.md %})
-:  Filter product by price, manufacturer, or any other criteria to reduce the time to purchase.
+Sophisticated Search
+:  [Filter product]({{ site.baseurl }}{% link marketing/seo-search.md %}) by price, manufacturer, or any other criteria to reduce the time to purchase.

--- a/src/quick-tour/home-page.md
+++ b/src/quick-tour/home-page.md
@@ -4,5 +4,5 @@ title: Home Page
 
 Did you know that most people spend only a few seconds on a page before they decide to stay or go somewhere else? That’s not long to make an impression! Studies show that people also love photographs, especially of other people. Whatever design you choose, everything on your home page should move visitors along toward the next step in the sales process. The idea is to guide their attention in a cohesive flow from one point of interest to the next.
 
-![]({{ site.baseurl }}{% link images/images/storefront-homepage-full.png %}){: .zoom}
-*Home Page*
+![Example storefront home page]({{ site.baseurl }}{% link images/images/storefront-homepage-full.png %}){: .zoom}
+_Home Page_

--- a/src/quick-tour/increase-average-order-value.md
+++ b/src/quick-tour/increase-average-order-value.md
@@ -4,28 +4,28 @@ title: Increase Average Order Value
 
 Magento provides a range of tools to help you tailor the shopping experience, and encourage your customers to put more items in their shopping carts and spend more money.
 
-[Targeted Promotions]({{ site.baseurl }}{% link marketing/promotions.md %})
-:  Use catalog and shopping cart price rules to create promotions that kick into gear when a set of conditions is met. {% if "Default.EE-B2B" contains site.edition %}Segment customers dynamically and build segments based on specific characteristics such as customer address, order history, shopping cart content, and much more. Then, use [Page Builder]({{ site.baseurl }}{% link cms/page-builder.md %}) to create a [dynamic block]({{ site.baseurl }}{% link cms/dynamic-blocks.md %}) that is triggered by a promotion, and appears only to the targeted customer segment.{% endif %}
+Targeted Promotions
+:  Use catalog and shopping cart price rules to create [promotions]({{ site.baseurl }}{% link marketing/promotions.md %}) that kick into gear when a set of conditions is met. {% if "Default.EE-B2B" contains site.edition %}Segment customers dynamically and build segments based on specific characteristics such as customer address, order history, shopping cart content, and much more. Then, use [Page Builder]({{ site.baseurl }}{% link cms/page-builder.md %}) to create a [dynamic block]({{ site.baseurl }}{% link cms/dynamic-blocks.md %}) that is triggered by a promotion, and appears only to the targeted customer segment.{% endif %}
 
-[Coupons]({{ site.baseurl }}{% link marketing/price-rules-cart-coupon.md %})
-:  Create limited-time offers and coupons that customers can scan with their phone and apply to a purchase.
+Coupons
+:  Create limited-time offers and [coupons]({{ site.baseurl }}{% link marketing/price-rules-cart-coupon.md %}) that customers can scan with their phone and apply to a purchase.
 
-[Product Suggestions]({{ site.baseurl }}{% link marketing/price-rules-cart-coupon.md %})
-:  Another way to increase AOV is to offer suggestions for related products and opportunities to up-sell and cross-sell at strategic points along the path to conversion.
-
+Product Suggestions
+:  Another way to increase AOV is to offer [suggestions]({{ site.baseurl }}{% link catalog/related-products-up-sells-cross-sells.md %}) for related products and opportunities to up-sell and cross-sell at strategic points along the path to conversion.
 <!--{% if "Default.EE-B2B" contains site.edition %}-->
-[Email Reminders]({{ site.baseurl }}{% link marketing/email-reminder-rules.md %})
-:  Send automated reminder emails to customers who have added items to their carts or wish lists, but haven’t made a purchase. A variety of triggers can launch automated emails, including total cart value, quantity, items in the cart, and more.<!--{% endif %}-->
 
-[User Permissions &amp; Roles]({{ site.baseurl }}{% link system/permissions.md %})
-:  Restrict access to data in the Admin on a “need to know” basis. Create multiple admin roles for read-only or and editing privileges. Track and review all activity at a granular level to specific stores and websites.
+Email Reminders
+:  Send automated [reminder emails]({{ site.baseurl }}{% link marketing/email-reminder-rules.md %}) to customers who have added items to their carts or wish lists, but haven’t made a purchase. A variety of triggers can launch automated emails, including total cart value, quantity, items in the cart, and more.<!--{% endif %}-->
 
-[Full-Page Caching]({{ site.baseurl }}{% link system/cache-full-page.md %})
-:  Enhance performance by caching primary pages. Caching pages improves server response times, reduces load, and increases sustainable traffic. You can use tags to define which components to cache, so only relevant pages are cached as updates take place. It also has the ability to identify and differentiate visitors from shoppers.
+User Permissions and Roles
+:  [Restrict access]({{ site.baseurl }}{% link system/permissions.md %}) to data in the Admin on a “need to know” basis. Create multiple admin roles for read-only or editing privileges. Track and review all activity at a granular level to specific stores and websites.
 
+Full-Page Caching
+:  Enhance performance by [caching primary pages]({{ site.baseurl }}{% link system/cache-full-page.md %}). Caching pages improves server response times, reduces load, and increases sustainable traffic. You can use tags to define which components to cache, so that only relevant pages are cached as updates take place. It also has the ability to identify and differentiate visitors from shoppers.
 <!--{% if "Default.EE-B2B" contains site.edition %}-->
-[Sales Order Archive]({{ site.baseurl }}{% link sales/order-archive.md %})
-:  Archiving orders frees resources and improves performance when sales reps are assisting customers with orders.<!--{% endif %}-->
 
-[Index Management]({{ site.baseurl }}{% link system/index-management.md %})
-:  Automatic reindexing takes place whenever prices change, shopping carts are updated, or new categories created. Reindexing is a background process that does not interfere with store operations.
+Sales Order Archive
+:  [Archiving orders]({{ site.baseurl }}{% link sales/order-archive.md %}) frees resources and improves performance when sales reps are assisting customers with orders.<!--{% endif %}-->
+
+Index Management
+:  Automatic [reindexing]({{ site.baseurl }}{% link system/index-management.md %}) takes place whenever prices change, shopping carts are updated, or new categories created. Reindexing is a background process that does not interfere with store operations.

--- a/src/quick-tour/increase-profitability.md
+++ b/src/quick-tour/increase-profitability.md
@@ -3,17 +3,17 @@ conditions: Default.B2B Only
 title: Increase Profitability
 ---
 
-[Maintain Peak Performance][1]
-: With Magento Cloud hosting, your site is always optimized, and ready to scale up to meet demand on the biggest sales day of the year.
+Maintain Peak Performance
+: With [Magento Cloud hosting][1]{: target="_blank"}, your site is always optimized, and ready to scale up to meet demand on the biggest sales day of the year.
 
-[Smart-Source Inventory][2]{: target="_blank"}
-: Increase profitability with smart-source inventory, and provide an “endless aisle” of product with [Magento Order Management][2]{: target="_blank"}. Supports both online and brick and mortar sales.
+Smart-Source Inventory
+: Increase profitability with smart-source inventory and provide an “endless aisle” of product with [Magento Order Management][2]{: target="_blank"}. Supports both online and brick and mortar sales.
 
-[Automated Business Rules]({{ site.baseurl }}{% link marketing/price-rules-cart.md %})
-: Set up automated business rules that define product relationships, and use price rules that trigger discounts based on a variety of conditions.
+Automated Business Rules
+: Set up [automated business rules]({{ site.baseurl }}{% link marketing/price-rules-cart.md %}) that define product relationships and use price rules that trigger discounts based on a variety of conditions.
 
-[Backend Integration]({{ site.baseurl }}{% link system/erp-systems.md %})
-: Integrate with Enterprise Resource Planning (ERP) other backend systems with our extensive APIs and open, modern platform.
+Backend Integration
+: Integrate with [Enterprise Resource Planning (ERP)]({{ site.baseurl }}{% link system/erp-systems.md %}) other backend systems with our extensive APIs and open, modern platform.
 
 [1]: https://magento.com/products/magento-commerce
 [2]: https://magento.com/products/order-management

--- a/src/quick-tour/loyalty-advocacy.md
+++ b/src/quick-tour/loyalty-advocacy.md
@@ -1,20 +1,20 @@
 ---
-title: Build Loyalty & Advocacy
+title: Build Loyalty and Advocacy
 ---
 
 Give customers a direct connection to your brand by allowing them to create customer accounts where they can see their purchase history, wish list, and newsletter subscription information. Use product ratings and reviews to give new customers objective product opinions and promote a sense of community. These features turn customer satisfaction into one of the most powerful and cost-efficient marketing tools at your disposal.
 
-[Advanced Reporting]({{ site.baseurl }}{% link reports/advanced-reporting.md %})
-:  Gain valuable insights at a glance with dynamic product, order, and customer reports, powered by Magento Business Intelligence.
+Advanced Reporting
+:  Gain valuable insights at a glance with dynamic product, order, and customer [reports]({{ site.baseurl }}{% link reports/advanced-reporting.md %}), powered by Magento Business Intelligence.
 
-[Dashboard Snapshots]({{ site.baseurl }}{% link stores/admin-dashboard.md %})
-:  Knowing what’s of interest on your site is crucial to maximize your marketing budget. Use this information to determine what you should cross- and up-sell to loyal customers, or which products to put on sale.
+Dashboard Snapshots
+:  Knowing what’s of interest on your site is crucial to maximize your marketing budget. Use this [information on your dashboard]({{ site.baseurl }}{% link stores/admin-dashboard.md %}) to determine what you should cross- and up-sell to loyal customers, or which products to put on sale.
 
-[Customer Accounts]({{ site.baseurl }}{% link customers/customer-account.md %})
-:  Opening an account provides customers with a personalized shopping experience that they can share with their friends. Customers can save their shopping preferences, and manage their own store billing and shipping information.
+Customer Accounts
+:  Opening an account provides [customers]({{ site.baseurl }}{% link customers/customer-account.md %}) with a personalized shopping experience that they can share with their friends. Customers can save their shopping preferences, and manage their own store billing and shipping information.
 
-[Advocacy Tools]({{ site.baseurl }}{% link marketing/shopping-tools.md %})
-:  Customers who share [wish lists]({{ site.baseurl }}{% link marketing/wishlists.md %}) {% if "Default.EE-B2B" contains site.edition %}and send [gift cards]({{ site.baseurl }}{% link catalog/product-gift-card.md %}){% endif %} make a powerful endorsement of your brand. Wish lists become powerful advocacy tools when shared by email or RSS feed, and gift cards bring motivated new shoppers to your store.
+Advocacy Tools
+:  Customers who share [wish lists]({{ site.baseurl }}{% link marketing/wishlists.md %}) {% if "Default.EE-B2B" contains site.edition %}and send [gift cards]({{ site.baseurl }}{% link catalog/product-gift-card.md %}){% endif %} make a powerful endorsement of your brand. Wish lists become powerful advocacy tools when shared by email or RSS feed{% if "Default.EE-B2B" contains site.edition %}, and gift cards bring motivated new shoppers to your store{% endif %}.
 
-[Reviews &amp; Ratings]({{ site.baseurl }}{% link marketing/product-reviews.md %})
-:  Product reviews give your customers a way to engage with your brand while fostering a sense of community. You can curate your reviews with tools to help you edit and approve comments for inappropriate content before they go live.
+Reviews and Ratings
+:  [Product reviews]({{ site.baseurl }}{% link marketing/product-reviews.md %}) give your customers a way to engage with your brand while fostering a sense of community. You can curate your reviews with tools to help you edit and approve comments for inappropriate content before they go live.

--- a/src/quick-tour/market-opportunities.md
+++ b/src/quick-tour/market-opportunities.md
@@ -3,17 +3,17 @@ conditions: Default.B2B Only
 title: Seize Market Opportunities
 ---
 
-[Business Intelligence][1]{: target="_blank"}
+Business Intelligence
 :  Use [Magento Business Intelligence][1]{: target="_blank"} to visually analyze your data, identify trends, and make smarter decisions. Discover hidden opportunities in long-tail market segments that can be targeted and developed over time.
 
-[Geographic Locations]({{ site.baseurl }}{% link stores/websites-stores-views.md %})
-:  Expand into new markets and geographic locations with multiple sites and stores for different locales and markets.
+Geographic Locations
+:  Expand into new markets and geographic locations with [multiple sites and stores]({{ site.baseurl }}{% link stores/websites-stores-views.md %}) for different locales and markets.
 
-[New Visions and Product Lines]({{ site.baseurl }}{% link marketing.md %})
+New Visions and Product Lines
 :  Create a [specialized sites]({{ site.baseurl }}{% link stores/websites-stores-views.md %})
 for a specific brand or product. Hold an invitation-only [event]({{ site.baseurl }}{% link marketing/events-private-sales.md %}) to launch a brand, and offer a [count-down ticker]({{ site.baseurl }}{% link marketing/event-ticker.md %}) to member-only sales.
 
-[B2B and B2C]({{ site.baseurl }}{% link quick-tour/path-to-purchase.md %})
-:  With Magento Commerce for B2B, you can serve both B2C and B2B customers.
+[B2B and B2C]
+:  With Magento Commerce for B2B, you can serve both [B2C and B2B customers]({{ site.baseurl }}{% link quick-tour/path-to-purchase.md %}).
 
 [1]: https://magento.com/products/business-intelligence

--- a/src/quick-tour/moment-of-purchase.md
+++ b/src/quick-tour/moment-of-purchase.md
@@ -4,29 +4,26 @@ title: Moment of Purchase
 
 Now that you’ve given your customer an engaging shopping experience, make it easy for them to complete their purchases. Magento is designed to help you streamline your checkout process experience while boosting conversion rates.
 
-[Instant Purchase]({{ site.baseurl }}{% link sales/checkout-instant-purchase.md %})
-:  Simplify ordering and boost conversion rates by allowing your customers to speed through checkout by using stored payment and shipping information.
+Instant Purchase
+:  Simplify ordering and boost conversion rates by allowing your customers to [speed through checkout]({{ site.baseurl }}{% link sales/checkout-instant-purchase.md %}) by using stored payment and shipping information.
 
-[Shopping Assistance]({{ site.baseurl }}{% link sales/shopping-assistance.md %})
-:  Assisted shopping makes it easy for customer service reps to create orders for customers.{% if "Default.EE-B2B" contains site.edition %} Customer service reps have access to shopping cart contents, and can move items from a wish list to a shopping cart, apply coupon codes, and more.{% endif %}
+Shopping Assistance
+:  [Assisted shopping]({{ site.baseurl }}{% link sales/shopping-assistance.md %}) makes it easy for customer service reps to create orders for customers.{% if "Default.EE-B2B" contains site.edition %} Customer service reps have access to shopping cart contents, and can move items from a wish list to a shopping cart, apply coupon codes, and more.{% endif %}
 
-[Security]({{ site.baseurl }}{% link stores/security.md %})
-:  Whether an order is fulfilled online or over the phone, Magento provides sophisticated security, including [CAPTCHA]({{ site.baseurl }}{% link stores/security-captcha.md %}) and SSL encryption, with best-in-breed encryption and hashing algorithms to protect the security of the system.
+Security
+:  Whether an order is fulfilled online or over the phone, Magento provides [sophisticated security]({{ site.baseurl }}{% link stores/security.md %}), including [CAPTCHA]({{ site.baseurl }}{% link stores/security-captcha.md %}) and SSL encryption, with best-in-breed encryption and hashing algorithms to protect the security of the system.
 
-[Order Processing]({{ site.baseurl }}{% link sales/order-processing.md %})
-:  Magento supports a complete order processing workflow. It's easy to customize order statuses and track communications between sales reps and customers.
+Order Processing
+:  Magento supports a complete [order processing]({{ site.baseurl }}{% link sales/order-processing.md %}) workflow. It is easy to customize order statuses and track communications between sales reps and customers.
 
-[Multiple Payment Options]({{ site.baseurl }}{% link payment/payments.md %})
-:  Magento supports the payment methods and currencies needed for global commerce. You can choose the ones you want to offer, and at checkout, your customers can choose the ones they prefer.
+Multiple Payment Options
+:  Magento supports the [payment methods]({{ site.baseurl }}{% link payment/payments.md %}) and currencies needed for global commerce. You can choose the ones you want to offer, and your customers can choose the ones they prefer at checkout.
 
-[PayPal Merchant Solutions]({{ site.baseurl }}{% link payment/paypal.md %})
-:  It's easy to integrate a PayPal Payments account to provide your customers faster, more secure checkout options.
+PayPal Merchant Solutions
+:  It is easy to integrate a [PayPal Payments]({{ site.baseurl }}{% link payment/paypal.md %}) account to provide your customers faster, more secure checkout options.
 
-[Magento Shipping]({{ site.baseurl }}{% link shipping/magento-shipping.md %})
-:  Offer seamless access to global carrier networks, and use customer experience rules to streamline operations and automate processes.
+Magento Shipping
+:  [Magento Shipping]({{ site.baseurl }}{% link shipping/magento-shipping.md %}) provides seamless access to global carrier networks, and you can use customer experience rules to streamline operations and automate processes. It supports a variety of shipping methods so you can give your customers a choice at checkout. Customers can see a real-time estimate of shipping charges right from the shopping cart.
 
-[Multiple Shipping Options]({{ site.baseurl }}{% link shipping/shipping.md %})
-:  Magento supports a variety of shipping methods so you can give your customers a choice at checkout. Customers can see a real-time estimate of shipping charges right from the shopping cart.
-
-[Shipping Labels]({{ site.baseurl }}{% link shipping/shipping-labels.md %})
-:  Merchants have complete control over package characteristics such as weight and size. Shipping labels, rate, and bar code information originates directly from the carrier. Labels can be generated for single or multiple orders.
+Shipping Labels
+:  Merchants have complete control over package characteristics such as weight and size. [Shipping labels]({{ site.baseurl }}{% link shipping/shipping-labels.md %}), rate, and bar code information originates directly from the carrier. Labels can be generated for single or multiple orders.

--- a/src/quick-tour/moment-of-purchase.md
+++ b/src/quick-tour/moment-of-purchase.md
@@ -26,4 +26,4 @@ Magento Shipping
 :  [Magento Shipping]({{ site.baseurl }}{% link shipping/magento-shipping.md %}) provides seamless access to global carrier networks, and you can use customer experience rules to streamline operations and automate processes. It supports a variety of shipping methods so you can give your customers a choice at checkout. Customers can see a real-time estimate of shipping charges right from the shopping cart.
 
 Shipping Labels
-:  Merchants have complete control over package characteristics such as weight and size. [Shipping labels]({{ site.baseurl }}{% link shipping/shipping-labels.md %}), rate, and bar code information originates directly from the carrier. Labels can be generated for single or multiple orders.
+:  Merchants have complete control over package characteristics such as weight and size. [Shipping labels]({{ site.baseurl }}{% link shipping/shipping-labels.md %}), rate, and bar code information originates directly from the carrier. You can easily generate labels for a single order or for multiple orders.

--- a/src/quick-tour/path-to-purchase.md
+++ b/src/quick-tour/path-to-purchase.md
@@ -13,7 +13,7 @@ Home Page
 :  Your [home page]({{ site.baseurl }}{% link quick-tour/home-page.md %}) is like the front window display of your store. As the primary landing page, its design entices visitors to come inside for a closer look.
 
 Catalog Page
-:  The [Catalog page]({{ site.baseurl }}{% link quick-tour/catalog-page.md %}) shows products from your catalog in either a list or grid format. Customers can make selections  based on a category they choose from the main menu, by using the layered navigation on the left, or from the results of a search. They can examine the item in more detail, or placed it directly into the shopping cart.
+:  The [Catalog page]({{ site.baseurl }}{% link quick-tour/catalog-page.md %}) shows products from your catalog in either a list or grid format. Customers can make selections based on a category they choose from the main menu, by using the layered navigation on the left or from the results of a search. They can examine the item in more detail or place it directly into the shopping cart.
 
 Search Results
 :  Did you know that people who use [search]({{ site.baseurl }}{% link quick-tour/search-results.md %}) are nearly twice as likely to make a purchase as those who rely on navigation alone? You might consider these shoppers to be _pre-qualified_.

--- a/src/quick-tour/path-to-purchase.md
+++ b/src/quick-tour/path-to-purchase.md
@@ -2,21 +2,24 @@
 title: Path to Purchase
 ---
 
-The path customers take that leads to a sale is sometimes called the “path to purchase.” In this quick tour, we’ll take a look at pages of strategic value that customers usually visit while shopping in your store. Then, we’ll consider different store features that can be leveraged at each stage of the customer journey.
+The path customers take that leads to a sale is sometimes called the _path to purchase_. In this quick tour, we take a look at pages of strategic value that customers usually visit while shopping in your store. We also consider different store features that can be leveraged at each stage of the customer journey.
 
-[<!--{% if "Default.CE Only" contains site.edition %}-->![]({{ site.baseurl }}{% link images/images/storefront-homepage.png %}){: .zoom}<!--{% endif %}--><!--{% if "Default.EE-B2B" contains site.edition %}-->![]({{ site.baseurl }}{% link images/images-ee/storefront-homepage-ee.png %}){: .zoom}<!--{% endif %}-->]({{ site.baseurl }}{% link quick-tour/home-page.md %})
+<!--{% if "Default.CE Only" contains site.edition %}-->![storefront home page]({{ site.baseurl }}{% link images/images/storefront-homepage.png %}){: .zoom}
+<!--{% endif %}-->
+<!--{% if "Default.EE-B2B" contains site.edition %}-->![storefront home page]({{ site.baseurl }}{% link images/images-ee/storefront-homepage-ee.png %}){: .zoom}
+<!--{% endif %}-->
 
-[Home Page]({{ site.baseurl }}{% link quick-tour/home-page.md %})
-:  Your home page is like the front window display of your store. As the primary landing page, its design entices visitors to come inside for a closer look.
+Home Page
+:  Your [home page]({{ site.baseurl }}{% link quick-tour/home-page.md %}) is like the front window display of your store. As the primary landing page, its design entices visitors to come inside for a closer look.
 
-[Catalog Page]({{ site.baseurl }}{% link quick-tour/catalog-page.md %})
-:  This page shows products from your catalog in either a list or grid format. The selection can be based on a category chosen from the main menu, a choice made in the layered navigation on the left, or the results of a search. Any item can be examined in more detail, or placed directly into the shopping cart.
+Catalog Page
+:  The [Catalog page]({{ site.baseurl }}{% link quick-tour/catalog-page.md %}) shows products from your catalog in either a list or grid format. Customers can make selections  based on a category they choose from the main menu, by using the layered navigation on the left, or from the results of a search. They can examine the item in more detail, or placed it directly into the shopping cart.
 
-[Search Results]({{ site.baseurl }}{% link quick-tour/search-results.md %})
-:  Did you know that people who use search are nearly twice as likely to make a purchase as those who rely on navigation alone? You might consider these shoppers to be “pre-qualified.”
+Search Results
+:  Did you know that people who use [search]({{ site.baseurl }}{% link quick-tour/search-results.md %}) are nearly twice as likely to make a purchase as those who rely on navigation alone? You might consider these shoppers to be _pre-qualified_.
 
-[Product Page]({{ site.baseurl }}{% link quick-tour/product-page.md %})
-:  The product page provides detailed information about a specific item in your catalog. Shoppers can read reviews, add the product to their wish lists, compare it to other products, share the link with friends, and most importantly, place the item into their shopping carts.
+Product Page
+:  The [product page]({{ site.baseurl }}{% link quick-tour/product-page.md %}) provides detailed information about a specific item in your catalog. Customers can read reviews, add the product to their wish lists, compare it to other products, share the link with friends, and most importantly, place the item into their shopping carts.
 
-[Shopping Cart]({{ site.baseurl }}{% link quick-tour/shopping-cart.md %})
-:  The shopping cart lists each item by price and quantity selected, and calculates the subtotal. Shoppers can apply discount coupons, and generate an estimate of shipping and tax charges.
+Shopping Cart
+:  The [shopping cart]({{ site.baseurl }}{% link quick-tour/shopping-cart.md %}) lists each item by price and quantity selected, and calculates the subtotal. Shoppers can apply discount coupons, and generate an estimate of shipping and tax charges.

--- a/src/quick-tour/product-page.md
+++ b/src/quick-tour/product-page.md
@@ -2,7 +2,7 @@
 title: Product Page
 ---
 
-The product page has a lot going on! The first thing that catches your eye on the product page is the main image with a high-resolution zoom and thumbnail gallery. In addition to the price and availability, there’s a tabbed section with more information and a list of related products.
+The product page has a lot going on! The first thing that catches your eye on the product page is the main image with a high-resolution zoom and thumbnail gallery. In addition to the price and availability, there is a tabbed section with more information and a list of related products.
 
-![]({{ site.baseurl }}{% link images/images/storefront-product-page-full-m.png %}){: .zoom}
-*Product Page*
+![Example storefront product page]({{ site.baseurl }}{% link images/images/storefront-product-page-full-m.png %}){: .zoom}
+_Product Page_

--- a/src/quick-tour/reduce-ordering-errors.md
+++ b/src/quick-tour/reduce-ordering-errors.md
@@ -7,7 +7,7 @@ Streamlined Order Process
 :  [Quick Order]({{ site.baseurl }}{% link sales/quick-order.md %}) reduces the process to several clicks. Magento offers multiple ways to configure the [shopping cart]({{ site.baseurl }}{% link sales/cart-configuration.md %}) and [checkout process]({{ site.baseurl }}{% link sales/checkout-configuration.md %}), to eliminate manual data entry and reduce costly ordering errors.
 
 Assisted Sales
-:  Assign a [dedicated sales rep]({{ site.baseurl }}{% link sales/shopping-assistance.md %}) to each company account, who can access the customer’s shopping cart in real time, and offer personal assistance over the phone.
+:  Assign a [dedicated sales rep]({{ site.baseurl }}{% link sales/shopping-assistance.md %}) to each company account. The assigned sales rep can access the customer’s shopping cart in real time and offer personal assistance over the phone.
 
 Complete Inventory Visibility
 :  Add [Magento Order Management][1]{: target="_blank"} for complete inventory visibility with accurate, real-time inventory levels from all locations and supply chain partners. Drop-ship scheduled deliveries, and track inventory across multiple warehouse locations.
@@ -19,6 +19,6 @@ Custom Catalogs and Price Lists
 : Maintain different “shared” [catalogs with custom pricing]({{ site.baseurl }}{% link catalog/catalog-shared.md %}) for specific companies.
 
 Bulk Orders
-:  Create [bulk pricing tiers]({{ site.baseurl }}{% link customers/account-dashboard-order-by-sku.md %}) with per-unit costs and discounts according to order size. Buyers can [reorder]({{ site.baseurl }}{% link customers/account-dashboard-my-orders.md %}) from previous orders, or upload order data directly to the shopping cart.
+:  Create [bulk pricing tiers]({{ site.baseurl }}{% link customers/account-dashboard-order-by-sku.md %}) with per-unit costs and discounts according to order size. Buyers can [reorder]({{ site.baseurl }}{% link customers/account-dashboard-my-orders.md %}) from previous orders or upload order data directly to the shopping cart.
 
 [1]: https://magento.com/products/order-management

--- a/src/quick-tour/reduce-ordering-errors.md
+++ b/src/quick-tour/reduce-ordering-errors.md
@@ -3,23 +3,22 @@ conditions: Default.B2B Only
 title: Reduce Ordering Errors
 ---
 
-[Streamlined Order Process]({{ site.baseurl }}{% link sales/point-of-purchase.md %})
-:  [Quick Order]({{ site.baseurl }}{% link sales/quick-order.md %})
-reduces the process to several clicks. Magento offers multiple ways to configure the [shopping cart]({{ site.baseurl }}{% link sales/cart-configuration.md %}) and [checkout process]({{ site.baseurl }}{% link sales/checkout-configuration.md %}), to eliminate manual data entry, and reduce costly ordering errors.
+Streamlined Order Process
+:  [Quick Order]({{ site.baseurl }}{% link sales/quick-order.md %}) reduces the process to several clicks. Magento offers multiple ways to configure the [shopping cart]({{ site.baseurl }}{% link sales/cart-configuration.md %}) and [checkout process]({{ site.baseurl }}{% link sales/checkout-configuration.md %}), to eliminate manual data entry and reduce costly ordering errors.
 
-[Assisted Sales]({{ site.baseurl }}{% link sales/shopping-assistance.md %})
-:  Assign a dedicated sales rep to each company account, who can access the customer’s shopping cart in real time, and offer personal assistance over the phone.
+Assisted Sales
+:  Assign a [dedicated sales rep]({{ site.baseurl }}{% link sales/shopping-assistance.md %}) to each company account, who can access the customer’s shopping cart in real time, and offer personal assistance over the phone.
 
-[Complete Inventory Visibility][1]
+Complete Inventory Visibility
 :  Add [Magento Order Management][1]{: target="_blank"} for complete inventory visibility with accurate, real-time inventory levels from all locations and supply chain partners. Drop-ship scheduled deliveries, and track inventory across multiple warehouse locations.
 
-[SKU and Inventory Validation]({{ site.baseurl }}{% link sales/point-of-purchase.md %})
-:  Magento reduces ordering errors by automatically verifying the SKU and availability of all items before an order is submitted. Merchants can set the [out of stock threshold]({{ site.baseurl }}{% link catalog/inventory-configure-inventory-management.md %}) for each product, set backorder levels, and manage the messaging that appears in the storefront.
+SKU and Inventory Validation
+:  Magento reduces ordering errors by automatically [verifying the SKU and availability]({{ site.baseurl }}{% link sales/point-of-purchase.md %}) of all items before an order is submitted. Merchants can set the [out of stock threshold]({{ site.baseurl }}{% link catalog/inventory-configure-inventory-management.md %}) for each product, set backorder levels, and manage the messaging that appears in the storefront.
 
-[Custom Catalogs and Price Lists]({{ site.baseurl }}{% link catalog/catalog-shared.md %})
-: Maintain different “shared” catalogs with custom pricing for specific companies.
+Custom Catalogs and Price Lists
+: Maintain different “shared” [catalogs with custom pricing]({{ site.baseurl }}{% link catalog/catalog-shared.md %}) for specific companies.
 
-[Bulk Orders]({{ site.baseurl }}{% link customers/account-dashboard-order-by-sku.md %})
-:  Create bulk pricing tiers with per-unit costs and discounts according to order size. Buyers can [reorder]({{ site.baseurl }}{% link customers/account-dashboard-my-orders.md %}) from previous orders, or upload order data directly to the shopping cart.
+Bulk Orders
+:  Create [bulk pricing tiers]({{ site.baseurl }}{% link customers/account-dashboard-order-by-sku.md %}) with per-unit costs and discounts according to order size. Buyers can [reorder]({{ site.baseurl }}{% link customers/account-dashboard-my-orders.md %}) from previous orders, or upload order data directly to the shopping cart.
 
 [1]: https://magento.com/products/order-management

--- a/src/quick-tour/search-results.md
+++ b/src/quick-tour/search-results.md
@@ -2,10 +2,9 @@
 title: Search Results
 ---
 
-Did you know that people who use search are nearly twice as likely to make a purchase as those who rely on navigation alone? You might consider these shoppers to be “pre-qualified.”
+Did you know that people who use search are nearly twice as likely to make a purchase as those who rely on navigation alone? You might consider these shoppers to be _pre-qualified_.
 
 Your store has a Search box in the upper-right corner, and a link to Advanced Search in the footer. All of the search terms that shoppers submit are saved, so you can see exactly what they’re looking for. You can offer suggestions, and enter synonyms and common misspellings. Then, display a specific page when a search term is entered.
 
-![]({{ site.baseurl }}{% link images/images/storefront-search-results-page-full.png %}){: .zoom}
-*Search Results Page*
-
+![Example storefront search results page]({{ site.baseurl }}{% link images/images/storefront-search-results-page-full.png %}){: .zoom}
+_Search Results Page_

--- a/src/quick-tour/self-service-tools.md
+++ b/src/quick-tour/self-service-tools.md
@@ -3,23 +3,23 @@ conditions: Default.B2B Only
 title: Empower with Self-Service Tools
 ---
 
-[Self-Service Tools]({{ site.baseurl }}{% link customers/account-dashboard.md %})
-:  Magento’s self-service model empowers customers to manage their own accounts and ordering process.
+Self-Service Tools
+:  Magento’s self-service model provides an [account dashboard]({{ site.baseurl }}{% link customers/account-dashboard.md %}) that empowers customers to manage their own accounts and ordering process.
 
-[Corporate Accounts]({{ site.baseurl }}{% link customers/account-companies.md %})
-:  The company administrator can set up the company structure and teams of users.
+Corporate Accounts
+:  The company administrator can set up the [company structure]({{ site.baseurl }}{% link customers/account-companies.md %}) and teams of users.
 
-[Buyer Roles and Permissions]({{ site.baseurl }}{% link customers/account-company-roles-permissions.md %})
-:  Set up company buyers with various levels of permission to specific purchasing operations, sales information, and resources.
+Buyer Roles and Permissions
+:  Set up company buyers with various [levels of permission]({{ site.baseurl }}{% link customers/account-company-roles-permissions.md %}) to specific purchasing operations, sales information, and resources.
 
-[Payments On Account]({{ site.baseurl }}{% link payment/payment-on-account.md %})
-:  Allow companies to make purchases charged to their account, up to the credit limit that is specified in their profile.
+Payments On Account
+:  Allow companies to make [purchases charged to their account]({{ site.baseurl }}{% link payment/payment-on-account.md %}), up to the credit limit that is specified in their profile.
 
-[Negotiated Quotes]({{ site.baseurl }}{% link sales/quote-request.md %})
-:  Company buyers can request a quote from the shopping cart, and negotiate with the seller to reach a acceptable price per line item.
+Negotiated Quotes
+:  Company buyers can [request a quote]({{ site.baseurl }}{% link sales/quote-request.md %}) from the shopping cart, and then negotiate with the seller to reach a acceptable price per line item.
 
-[Quote Tracking]({{ site.baseurl }}{% link customers/account-dashboard-quotes.md %})
-:  A detailed history of all activity related to quotes, including all interactions between buyer and seller during the negotiation process is available from the company’s account and from the store’s back office Admin.
+Quote Tracking
+:  A detailed history of all [activity related to quotes]({{ site.baseurl }}{% link customers/account-dashboard-quotes.md %}), including all interactions between buyer and seller during the negotiation process, is available from the company’s account and from the store’s back office Admin.
 
-[Order History]({{ site.baseurl }}{% link customers/account-dashboard-my-orders.md %})
-:  From the convenience of the account dashboard, customers can create new orders based on past orders, track shipments, and print orders, invoices, shipments and refunds.
+Order History
+:  From the convenience of the account dashboard, customers can access their [order history]({{ site.baseurl }}{% link customers/account-dashboard-my-orders.md %}) and easily create new orders based on past orders, track shipments, and print orders, invoices, shipments and refunds.

--- a/src/quick-tour/shopping-cart.md
+++ b/src/quick-tour/shopping-cart.md
@@ -2,7 +2,7 @@
 title: Shopping Cart
 ---
 
-The cart is where order total can be determined, along with discount coupons and estimated shipping and tax, and is a great place to display your trust badges and seals. It’s also an ideal opportunity to offer one last item. As a cross-sell, you can select certain items to be offered as an impulse purchase whenever a specific item appears in the cart.
+The cart is where order total can be determined, along with discount coupons and estimated shipping and tax, and a great place to display your trust badges and seals. This is  also an ideal opportunity to offer one last item. As a cross-sell, you can select certain items to be offered as an impulse purchase whenever a specific item appears in the cart.
 
-![]({{ site.baseurl }}{% link images/images/storefront-cart-full.png %}){: .zoom}
-*Shopping Cart Page*
+![Example storefront shopping cart page]({{ site.baseurl }}{% link images/images/storefront-cart-full.png %}){: .zoom}
+_Shopping Cart Page_

--- a/src/quick-tour/success.md
+++ b/src/quick-tour/success.md
@@ -4,23 +4,24 @@ title: Success!
 
 Opening your Magento store for business requires the following areas of consideration. While there are virtually any number of customizations you can make to the storefront and Admin, you can use each link in this is list as a place to start.
 
-[Implementation][1]{: target="_blank"}
-:  If you need help setting up your store, you can choose from our vast network of Magento Solutions Partners.
+Implementation
+:  If you need help setting up your store, you can choose from our vast network of [Magento Solutions Partners][1]{: target="_blank"}.
 
-[Design][2]{: target="_blank"}
+Design
 :  You can use a prepared theme and design your own home page, or work with an experienced Magento designer or [Magento Associate][2]{: target="_blank"} to customize your site.
 
-[Product Catalog]({{ site.baseurl }}{% link catalog/products.md %})
-:  Configure products, create categories, import existing product catalogs, and leverage APIs or third-party data management solutions.
+Product Catalog
+:  Set up your [product catalog]({{ site.baseurl }}{% link catalog/products.md %})-add products, create categories, import existing product catalogs, and leverage APIs or third-party data management solutions.
 
-[Payment Methods]({{ site.baseurl }}{% link payment/payments.md %})
-:  Magento supports a wide variety of payment methods, services, and gateways that you can offer for your customers’ convenience.
+Payment Methods
+:  Magento supports a wide variety of [payment methods]({{ site.baseurl }}{% link payment/payments.md %}), services, and gateways that you can offer for your customers’ convenience.
 
-[Shipping Methods]({{ site.baseurl }}{% link shipping/shipping.md %})
-:  Magento shipping methods are easy to set up and give you the ability to connect with carriers who can ship your products all over the world.
+Shipping Methods
+:  Magento [shipping methods]({{ site.baseurl }}{% link shipping/shipping.md %}) are easy to set up and give you the ability to connect with carriers who can ship your products all over the world.
 
-[Taxes]({{ site.baseurl }}{% link tax/taxes.md %})
-:  Manage your taxes with our native tools, or add third-party extensions from Magento Marketplace.
+Taxes
+:  Manage your [taxes]({{ site.baseurl }}{% link tax/taxes.md %}) with our native tools, or add third-party extensions from [Magento Marketplace][3]{: target="_blank"}.
 
 [1]: https://magento.com/partners/overview
 [2]: https://partners.magento.com/partner_locator/associate_directory.aspx
+[3]: https://marketplace.magento.com/


### PR DESCRIPTION
## Purpose of this pull request

This was primarily as a fix for #23 (convert tables in quick-tour), but with reviewing the files in this folder I discovered there are no tables in any of these topics.

However, proceeded to clean up other formatting items and get these pages in better shape:

- Removed links from headings and the definition term items (in keeping with #17) and relocated to description text.
- Added alt text for images where needed
- Cleaned up a few areas where conditions for user guide editions was misapplied
- A few misc. formats to align with MD linting rules

## Affected documentation pages

These sections:

- https://docs.magento.com/m2/b2b/user_guide/getting-started/quick-tour.html
- (B2B only) https://docs.magento.com/m2/b2b/user_guide/quick-tour/b2b-quick-start.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B

## Additional information

Internal staging build 227
