### PR TITLE
Merchdocs-4 SEO Topics - Links to Rewrite Types

### DIFF
--- a/src/marketing/url-rewrite-create.md
+++ b/src/marketing/url-rewrite-create.md
@@ -25,3 +25,10 @@ Additional Category URLs
 
 ![]({% link images/images/url-rewrites.png %}){: .zoom}
 *URL Rewrites*
+
+Magento offers these URL rewrite types:
+
+* [Product Rewrites]({% link marketing/url-rewrite-product.md %})
+* [Category Rewrites]({% link marketing/url-rewrite-category.md %})
+* [CMS Page Rewrites]({% link marketing/url-rewrite-cms-page.md %})
+* [Custom Rewrites]({% link marketing/url-rewrite-custom.md %})


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes part of the issue #4 where it requires more info on how to use the Rewrite Tool on the page Creating URL Rewrites. Instead of adding the step by step guide right there, I linked to the pages for all rewrite types (e. g. CMS Page Rewrites) where the step by step guide is already available. The idea behind it is to make it easier for users to find the step by step guide without creating more duplicate content.

## Affected documentation pages

### Updated page

- https://docs.magento.com/m2/ce/user_guide/marketing/url-rewrite-create.html

## Affected Magento editions

- [X] Open Source
- [X] Commerce
- [ ] B2B


## Additional information

Fixes part of #4 