### PR TITLE
Convert HTML tables - system folder

### DIFF
--- a/src/system/action-log-report.md
+++ b/src/system/action-log-report.md
@@ -65,7 +65,7 @@ _Action Logs Report Filters_
     -  **CSV**: A comma-separated value file containing plain text data
     -  **Excel XML**: An XML-based, spreadsheet data format
 
-2.  Click **Export**. The generated file saves automatically to your designated folder for downloads.
+1.  Click **Export**. The generated file saves automatically to your designated folder for downloads.
 
     ![]({% link images/images-ee/system-action-log-report-export.png %}) 
     _Action Logs Report Export_

--- a/src/system/action-log-report.md
+++ b/src/system/action-log-report.md
@@ -44,55 +44,19 @@ To clear the filter options and return to the full report, click **Reset Filter*
 ![]({% link images/images-ee/system-action-log-report-filters.png %}){: .zoom}
 _Action Logs Report Filters_
 
-<table>
-  <h3 class="TableHeading">Filter by Field</h3>
-  <thead>
-     <tr>
-        <th>Field</th>
-        <th>description</th>
-     </tr>
-  </thead>
-  <tbody>
-     <tr>
-        <td>Time</td>
-        <td>
-           <p>In <b>From</b>, click to select a date from the dynamic calendar to define the beginning date for the filter. Then in <b>To</b>, click to select a date from the dynamic calendar to define the ending date for the filter.</p>
-        </td>
-     </tr>
-     <tr>
-        <td>Action Group</td>
-        <td>Choose an option in the drop-down field.</td>
-     </tr>
-     <tr>
-        <td>
-           <p>Action</p>
-        </td>
-        <td>Choose an option in the drop-down field.</td>
-     </tr>
-     <tr>
-        <td>IP Address</td>
-        <td>Enter the IP address of the machine used for an action.</td>
-     </tr>
-     <tr>
-        <td>Username</td>
-        <td>
-           <p>Choose an username option in the dropdown field. Default is All Users.</p>
-        </td>
-     </tr>
-     <tr>
-        <td>Result</td>
-        <td>Choose Success or Failure in the drop-down field.</td>
-     </tr>
-     <tr>
-        <td>Full Action Name</td>
-        <td>Enter text for the search to match in the field.</td>
-     </tr>
-     <tr>
-        <td>Details</td>
-        <td>Enter text for the search to match in the field.</td>
-     </tr>
-  </tbody>
-</table>
+### Filter by Field
+
+|Field|description|
+|--- |--- |
+|Time|In **From**, click to select a date from the dynamic calendar to define the beginning date for the filter. Then in **To**, click to select a date from the dynamic calendar to define the ending date for the filter.|
+|Action Group|Choose an option in the drop-down field.|
+|Action|Choose an option in the drop-down field.|
+|IP Address|Enter the IP address of the machine used for an action.|
+|Username|Choose an username option in the dropdown field. Default is All Users.|
+|Result|Choose Success or Failure in the drop-down field.|
+|Full Action Name|Enter text for the search to match in the field.|
+|Details|Enter text for the search to match in the field.|
+
 
 #### To export the action logs report:
 
@@ -101,7 +65,7 @@ _Action Logs Report Filters_
     -  **CSV**: A comma-separated value file containing plain text data
     -  **Excel XML**: An XML-based, spreadsheet data format
 
-1.  Click **Export**. The generated file saves automatically to your designated folder for downloads.
+2.  Click **Export**. The generated file saves automatically to your designated folder for downloads.
 
     ![]({% link images/images-ee/system-action-log-report-export.png %}) 
     _Action Logs Report Export_

--- a/src/system/data-attributes-customer.md
+++ b/src/system/data-attributes-customer.md
@@ -6,353 +6,59 @@ The following tables list the attributes from a typical export of the Customers 
 
 Each attribute, or field, is represented in the CSV file as a column, and customer records are represented by rows. Columns that begin with an underscore are service entities that contain properties or complex data.
 
-<table>
-      <h3 class="TableHeading">Customers Main File</h3>
-      <thead>
-         <tr>
-            <th>Attribute</th>
-            <th>Description</th>
-         </tr>
-      </thead>
-      <tbody>
-         <tr>
-            <td>
-               <code>email</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>_website</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>_store</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>confirmation</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>created_at</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>created_in</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>disable_auto_group_change</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>dob</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>firstname</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>gender</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>group_id</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>lastname</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>middlename</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>password_hash</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>prefix</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>rp_token</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>rp_token_created_at</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>store_id</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>suffix</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>taxvat</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>website_id</code>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <code>password</code>
-            </td>
-            <td> </td>
-         </tr>
-      </tbody>
-   </table>
-<table>
-      <h3 class="TableHeading">Customer Addresses</h3>
-      <thead>
-         <tr>
-            <th>Attribute</th>
-            <th>Description</th>
-         </tr>
-      </thead>
-      <tbody>
-         <tr>
-            <td>
-               <p>
-                  <code>_website</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>_email</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>_entity_id</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>city</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>company</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>country_id</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>fax</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>firstname</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>lastname</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>middlename</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>postcode</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>prefix</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>region</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>region_id</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>street</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>suffix</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>telephone</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>vat_id</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>vat_is_valid</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>vat_request_date</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>vat_request_id</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>vat_request_success</code>
-               </p>
-            </td>
-            <td> </td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>_address_default_billing_</code>
-               </p>
-            </td>
-            <td>Identifies the default billing address. A value of 1 indicates that the address is the default billing address of the customer. Values: 1 / 0</td>
-         </tr>
-         <tr>
-            <td>
-               <p>
-                  <code>_address_default_shipping_</code>
-               </p>
-            </td>
-            <td>Identifies the default shipping address. A value of 1 indicates that the address is the default shipping address of the customer. Values: 1 / 0</td>
-         </tr>
-         <tr>
-            <td> </td>
-            <td> </td>
-         </tr>
-      </tbody>
-   </table>
+### Customers Main File
+
+|Attribute|Description|
+|--- |--- |
+|`email`||
+|`_website`||
+|`_store`||
+|`confirmation`||
+|`created_at`||
+|`created_in`||
+|`disable_auto_group_change`||
+|`dob`||
+|`firstname`||
+|`gender`||
+|`group_id`||
+|`lastname`||
+|`middlename`||
+|`password_hash`||
+|`prefix`||
+|`rp_token`||
+|`rp_token_created_at`||
+|`store_id`||
+|`suffix`||
+|`taxvat`||
+|`website_id`||
+|`password`||
+
+### Customer Addresses
+
+|Attribute|Description|
+|--- |--- |
+|`_website`||
+|`_email`||
+|`_entity_id`||
+|`city`||
+|`company`||
+|`country_id`||
+|`fax`||
+|`firstname`||
+|`lastname`||
+|`middlename`||
+|`postcode`||
+|`prefix`||
+|`region`||
+|`region_id`||
+|`street`||
+|`suffix`||
+|`telephone`||
+|`vat_id`||
+|`vat_is_valid`||
+|`vat_request_date`||
+|`vat_request_id`||
+|`vat_request_success`||
+|`_address_default_billing_`|Identifies the default billing address. A value of 1 indicates that the address is the default billing address of the customer. Values: 1 / 0|
+|`_address_default_shipping_`|Identifies the default shipping address. A value of 1 indicates that the address is the default shipping address of the customer. Values: 1 / 0|
+|||

--- a/src/system/data-export-criteria.md
+++ b/src/system/data-export-criteria.md
@@ -21,43 +21,10 @@ To include only records with a specific value, such as a SKU, type the value int
 
 The checkbox in the first column is used to exclude attributes from the export file. If an attribute is excluded, the associated column in the export data is included, but empty.
 
-<table>
-      <h3 class="TableHeading">Export Criteria</h3>
-      <thead>
-         <tr>
-            <th>Exclude</th>
-            <th>Filter</th>
-            <th>Result</th>
-         </tr>
-      </thead>
-      <tbody>
-         <tr>
-            <td>
-               <img src="{% link images/images/btn-exclude-unchecked.png %}" />
-            </td>
-            <td> No</td>
-            <td>The exported file contains each attribute for all existing records.</td>
-         </tr>
-         <tr>
-            <td>
-               <img src="{% link images/images/btn-exclude-unchecked.png %}" />
-            </td>
-            <td>Yes</td>
-            <td>The export file contains each attribute with only the records allowed by the filter.</td>
-         </tr>
-         <tr>
-            <td>
-               <img src="{% link images/images/btn-exclude-checked.png %}" />
-            </td>
-            <td>No</td>
-            <td>The export file does not include the column for the excluded attribute, but does include all existing records.</td>
-         </tr>
-         <tr>
-            <td>
-               <img src="{% link images/images/btn-exclude-checked.png %}" />
-            </td>
-            <td> Yes</td>
-            <td>The export file does not include the column for the excluded attribute, and contains only the records allowed by the filter.</td>
-         </tr>
-      </tbody>
-   </table>
+|Exclude|Filter|Result|
+|--- |--- |--- |
+|![]({% link link images/images/btn-exclude-unchecked.png %})|No|The exported file contains each attribute for all existing records.|
+|![]({% link link images/images/btn-exclude-unchecked.png %})|Yes|The export file contains each attribute with only the records allowed by the filter.|
+|![]({% link link images/images/btn-exclude-checked.png %})|No|The export file does not include the column for the excluded attribute, but does include all existing records.|
+|![]({% link link images/images/btn-exclude-checked.png %})|Yes|The export file does not include the column for the excluded attribute, and contains only the records allowed by the filter.|
+

--- a/src/system/permissions-role-resources.md
+++ b/src/system/permissions-role-resources.md
@@ -69,18 +69,14 @@ Access to the following resources can be assigned to a custom role. See the link
          </tr>
          <tr>
             <td> </td>
-            <td>
-               <p> </p>
-            </td>
+            <td> </td>
             <td>
                <a href="{% link catalog/products.md %}">Products</a>
             </td>
          </tr>
          <tr>
             <td> </td>
-            <td>
-               <p> </p>
-            </td>
+            <td> </td>
             <td>
                <a href="{% link catalog/categories.md %}">Categories</a>
             </td>
@@ -198,9 +194,7 @@ Access to the following resources can be assigned to a custom role. See the link
             <td>
                <a href="{% link customers/customer-account.md %}">My Account</a>
             </td>
-            <td>
-               <p> </p>
-            </td>
+            <td> </td>
             <td> </td>
          </tr>
          <tr>

--- a/src/system/permissions-users-all.md
+++ b/src/system/permissions-users-all.md
@@ -68,18 +68,7 @@ _Example Admin Users_
     ![]({% link images/images/permissions-user-roles.png %}){: .zoom}
     _Add New User Role_
 
-    <table>
-      <h3 class="TableHeading">Admin Password Requirements</h3>
-      <thead>
-         <tr>
-            <th>Field</th>
-            <th>Description</th>
-         </tr>
-      </thead>
-      <tbody>
-         <tr>
-            <td>Password</td>
-            <td>An Admin password must be seven or more characters long, and include both letters and numbers. For additional password options, see: <a href="{% link stores/security-admin.md %}">Configuring Admin Security</a>.</td>
-         </tr>
-      </tbody>
-    </table>
+   |Field|Description|
+   |--- |--- |
+   |Password|An Admin password must be seven or more characters long, and include both letters and numbers. For additional password options, see: [Configuring Admin Security.]({% link stores/security-admin.md %})|
+

--- a/src/system/web-setup.md
+++ b/src/system/web-setup.md
@@ -132,11 +132,15 @@ To learn more, see [File systems access permissions][2]{: target="_blank"}.
 
 Change to the Web user who has full permissions to the Magento2 folder. (For example, apache or root.)
 
-<table><tbody><tr><td><pre>su – apache</pre></td></tr></tbody></table>
+```
+su – apache
+```
 
 Change directories to the Magento2 folder, and set the following permissions. You can copy the code, and paste it as a single command.
 
-<table><tbody><tr><td><pre>find . -type d -exec chmod 700 {} ; &amp;&amp; find . -type f -exec chmod 600 {} ; &amp;&amp; chmod +x bin/magento</pre></td></tr></tbody></table>
+```
+find . -type d -exec chmod 700 {} ; && find . -type f -exec chmod 600 {} ; && chmod +x bin/magento
+```
 
 [1]: http://devdocs.magento.com/guides/v2.3/install-gde/install-quick-ref.html
 [2]: https://devdocs.magento.com/guides/v2.3/config-guide/prod/prod_file-sys-perms.html


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request converts the HTML tables in System section into markdown
https://github.com/magento/merchdocs/issues/27

## Affected documentation pages

Pages touched by this PR :)

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [ ] B2B

## Additional information

Most of the tables were converted except the one in permissions-role-resources.md
This table uses links and is a kind of index. This index can be converted into some kind of list one day.
As long as it is a table - it is easier to maintain it as an HTML table (it uses <br> and conditions) than one line in markdown table

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in a release integration branch.

See Contribution guidelines (https://github.com/magento/merchdocs/blob/master/.github/CONTRIBUTING.md) and wiki (https://github.com/magento/merchdocs/wiki) for more information.
-->
