### PR TITLE
Fix text for product pages sitemap XML configuration

### DIFF
--- a/src/configuration/catalog/xml-sitemap.md
+++ b/src/configuration/catalog/xml-sitemap.md
@@ -21,7 +21,7 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Cata
 
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |
-|Frequency|Store View|Determines how often sitemap CMS pages are updated. Options: Always / Hourly / Daily / Weekly / Monthly / Yearly / Never|
+|Frequency|Store View|Determines how often sitemap products are updated. Options: Always / Hourly / Daily / Weekly / Monthly / Yearly / Never|
 |Priority|Store View|A value between 0.0 and 1.0 that determines the priority of product sitemap updates in relation to other content. Zero has the lowest priority.|
 
 ## CMS Pages Options


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) will fix that CMS pages are mentioned instead of product pages in the "Product options" section.

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on Open Source https://docs.magento.com/m2/ce/user_guide/ or Commerce or B2B. Not needed for large numbers of files. -->

- https://docs.magento.com/m2/ce/user_guide/configuration/catalog/xml-sitemap.html
- https://docs.magento.com/m2/ee/user_guide/configuration/catalog/xml-sitemap.html
- https://docs.magento.com/m2/b2b/user_guide/configuration/catalog/xml-sitemap.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B