### PR TITLE
Remove extra ending `</td>` from vat.md

### DIFF
--- a/src/tax/vat.md
+++ b/src/tax/vat.md
@@ -14,7 +14,7 @@ Magento uses the following VAT fields and configuration settings to address diff
 
 **Stores** > **Configuration** > **General** > **General** > **Store Information**
 
-- `VAT Number` — The value-added tax number that is assigned to the merchant.</td>
+- `VAT Number` — The value-added tax number that is assigned to the merchant.
 - `Validate VAT Number` — [VAT validation]({% link tax/vat-validation.md %}) confirms that the VAT Number matches the corresponding record in the [European Commission](http://ec.europa.eu/taxation_customs/vies/") database.
 
 ## Customer Information
@@ -23,7 +23,7 @@ Magento uses the following VAT fields and configuration settings to address diff
 
 - **Account Information**
 
-  - `Tax/VAT Number` — If applicable, the tax number or value-added tax number that is assigned to the customer.</td>
+  - `Tax/VAT Number` — If applicable, the tax number or value-added tax number that is assigned to the customer.
 
 - **Addresses**
 


### PR DESCRIPTION
## Purpose of this pull request

There are a few extra ending `td` tags that slipped into this page:
![vat](https://user-images.githubusercontent.com/4011193/68694262-778c0e00-053e-11ea-9fc2-b8cf4108d8b8.png)

This pull request (PR) ...

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on Open Source https://docs.magento.com/m2/ce/user_guide/ or Commerce or B2B. Not needed for large numbers of files. -->

- [Value Added Tax (VAT)](https://docs.magento.com/m2/ee/user_guide/tax/vat.html)
## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in a release integration branch.

See Contribution guidelines (https://github.com/magento/merchdocs/blob/master/.github/CONTRIBUTING.md) and wiki (https://github.com/magento/merchdocs/wiki) for more information.
-->
