### PR TITLE
Fix navigation for PayPal pages

### DIFF
--- a/src/_data/b2b/toc/getting-started.yml
+++ b/src/_data/b2b/toc/getting-started.yml
@@ -39,7 +39,7 @@ pages:
       - label: Increase Profitability
         url: "/quick-tour/increase-profitability.html"
       - label: Seize Market Opportunities
-        url: "/quick-tour/market-opportunities.html"    
+        url: "/quick-tour/market-opportunities.html"
   - label: " Quick Tour"
     url: "/getting-started/quick-tour.html"
     children:
@@ -296,16 +296,20 @@ pages:
       - label: Other PayPal Methods
         url: "/configuration/sales/paypal-methods-other.html"
         children:
-        - label: PayPal Payments Advanced
-          url: "/configuration/sales/paypal-payments-advanced.html"
-        - label: PayPal Payments Pro
-          url: "/configuration/sales/paypal-payments-pro.html"
-        - label: PayPal Payments Standard
-          url: "/configuration/sales/paypal-payments-standard.html"
-        - label: PayPal Payflow Pro
-          url: "/configuration/sales/paypal-payflow-pro.html"
-        - label: PayPal Payflow Link
-          url: "/configuration/sales/paypal-payflow-link.html"
+        - label: PayPal All-In-One Payment Solutions
+          children:
+          - label: PayPal Payments Advanced
+            url: "/configuration/sales/paypal-payments-advanced.html"
+          - label: PayPal Payments Pro
+            url: "/configuration/sales/paypal-payments-pro.html"
+          - label: PayPal Payments Standard
+            url: "/configuration/sales/paypal-payments-standard.html"
+        - label: PayPal Payment Gateways
+          children:
+          - label: PayPal Payflow Pro
+            url: "/configuration/sales/paypal-payflow-pro.html"
+          - label: PayPal Payflow Link
+            url: "/configuration/sales/paypal-payflow-link.html"
       - label: Other Payment Methods
         url: "/configuration/sales/payment-methods-other.html"
         children:

--- a/src/_data/ce/toc/getting-started.yml
+++ b/src/_data/ce/toc/getting-started.yml
@@ -251,7 +251,7 @@ pages:
         - label: Braintree
           url: "/configuration/sales/braintree.html"
       - label: Other PayPal Methods
-        url: "/configuration/sales/payment-methods-other.html"
+        url: "/configuration/sales/paypal-methods-other.html"
         children:
         - label: PayPal All-In-One Payment Solutions
           children:

--- a/src/_data/ee/toc/getting-started.yml
+++ b/src/_data/ee/toc/getting-started.yml
@@ -259,7 +259,7 @@ pages:
         - label: Braintree
           url: "/configuration/sales/braintree.html"
       - label: Other PayPal Methods
-        url: "/configuration/sales/payment-methods-other.html"
+        url: "/configuration/sales/paypal-methods-other.html"
         children:
         - label: PayPal All-In-One Payment Solutions
           children:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will:

* fix links to the "Other PayPal methods" section in the navigation for OS and Commerce (they link to the "Other Payment methods" pages currently)
* add the same sub menus to the B2B documentation for PayPal payment methods as already existing in the OS/Commerce versions.

## Affected documentation pages

Amongst others:

* https://docs.magento.com/m2/ce/user_guide/configuration/sales/payment-methods.html
* https://docs.magento.com/m2/ee/user_guide/configuration/sales/payment-methods.html
* https://docs.magento.com/m2/b2b/user_guide/configuration/sales/payment-methods.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B
