### PR TITLE
Add raw for sample code

### DIFF
--- a/src/marketing/variables-custom.md
+++ b/src/marketing/variables-custom.md
@@ -38,5 +38,8 @@ _Custom Variables_
    
   Your custom variable is now available to be inserted into email and newsletter templates and other types of content.  The code that is inserted looks similar to the following [markup tag]({% link marketing/markup-tags.md -%}):
 
-  `{{CustomVar code= "my_custom_variable"}}`
-  
+<!-- {%- raw -%} -->
+```
+  {{CustomVar code= "my_custom_variable"}}
+```
+<!-- {% endraw %} -->


### PR DESCRIPTION
## Purpose of this pull request

Fix liquid warning: 

`Liquid Warning: Liquid syntax error (line 35): Unexpected character = in "{{CustomVar code= "my_custom_variable"}}" in marketing/variables-custom.md`

## Affected documentation pages

- https://docs.magento.com/m2/ee/user_guide/marketing/variables-custom.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B


