### PR TITLE
Add MBI to search and update site switcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/magento-devdocs/devdocs-theme.git
-  revision: 7628949ce6d16a6232a0582b32465757a6e446a9
+  revision: 42b6ebb8748ae5a3dc836d6891063dbebf31cbfe
   specs:
     devdocs (7)
       jekyll (>= 4.0)

--- a/src/_includes/layout/header-scripts.html
+++ b/src/_includes/layout/header-scripts.html
@@ -14,6 +14,11 @@
       baseUrl: "{{ site.baseurl }}"
     },
     {
+      label: "MBI User Guide",
+      name: "merchdocs-mbi",
+      baseUrl: "https://docs.magento.com/mbi"
+    },
+    {
       label: "DevDocs",
       name: "devdocs",
       facetFilters: [["guide_version: 2.3", "versionless: true"]],


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) add MBI User Guide to federated search and update the link in site switcher.

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on Open Source https://docs.magento.com/m2/ce/user_guide/ or Commerce or B2B. Not needed for large numbers of files. -->

- ...
- ...

## Affected Magento editions

- [ ] Open Source
- [ ] Commerce
- [ ] B2B

## Links to Magento source code or PRs

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository or a code PR, add it here. -->

- ...
- ...

## Additional information

<!-- (OPTIONAL) What other information can you provide? -->

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in a release integration branch.

See Contribution guidelines (https://github.com/magento/merchdocs/blob/master/.github/CONTRIBUTING.md) and wiki (https://github.com/magento/merchdocs/wiki) for more information.
-->
