### PR TITLE
Expanding page builder image functionality to call out Adobe Stock Integration usage

### DIFF
--- a/src/cms/page-builder-media-image.md
+++ b/src/cms/page-builder-media-image.md
@@ -24,13 +24,15 @@ _Image In Column_
 
     **Upload New Image**
 
-    - Click <span class="btn">Upload New Image</span>.
+    - Click <span class="btn">Upload Image</span>.
 
     - Navigate to the image in your local file system. Then, choose the image to add it to the gallery and target container.
 
     **Select from Gallery**
 
     - Click <span class="btn">Select from Gallery</span>.
+
+    - Optionally, you can use the [Adobe Stock Integration]({% link cms/adobe-stock.md %}) to find and save an appropriate asset from among the millions provided by [Adobe Stock](https://stock.adobe.com). Check out the [full Adobe Stock Integration usage instructions]({% link cms/adobe-stock-manage.md %}) for details on how to search, refine and save Adobe Stock assets into your Gallery. Once you save an Adobe Stock asset, you will be returned to the gallery.
 
     - In the gallery, navigate to the image and click the thumbnail. Then, click <span class="btn">Add Selected</span>.
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) expands on page builder image functionality documentation to call out the option of using the Adobe Stock Integration to pull in images for use when using the Page Builder. Also updated one of the button labels to reflect the screenshot appropriately.

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on Open Source https://docs.magento.com/m2/ce/user_guide/ or Commerce or B2B. Not needed for large numbers of files. -->

- `src/cms/page-builder-media-image.md`

## Affected Magento editions

- [ ] Open Source
- [x] Commerce
- [x] B2B

## Links to Magento source code or PRs

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository or a code PR, add it here. -->

- This PR relies on #187 as it links to documents contained within #187.

## Additional information

<!-- (OPTIONAL) What other information can you provide? -->

This PR fixes #88.

FYI @sivaschenko @diazwatson @konarshankar07

<!-- 
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in a release integration branch.

See Contribution guidelines (https://github.com/magento/merchdocs/blob/master/.github/CONTRIBUTING.md) and wiki (https://github.com/magento/merchdocs/wiki) for more information.
-->
