### PR TITLE
DOC-53-compliance-link-fix

### DIFF
--- a/src/stores/compliance-ccpa-guide.md
+++ b/src/stores/compliance-ccpa-guide.md
@@ -168,6 +168,6 @@ Review your current privacy policy and consider what, if any, additional disclos
 For a period of 24 months after each individual rights request is received, maintain a record of the request and your company's response.
 
 [1]: https://devdocs.magento.com/compliance/privacy/pi-data-reference-m2.html
-[2]: https://devdocs.magento.com/compliance/privaxy/pi-data-reference-m1.html
+[2]: https://devdocs.magento.com/compliance/privacy/pi-data-reference-m1.html
 [3]: https://oag.ca.gov/system/files/attachments/press_releases/CCPA%20Fact%20Sheet%20%2800000002%29.pdf
 [4]: https://www.adobe.com/commerce/magento.html


### PR DESCRIPTION
The purpose of this PR is to fix a typo in a link from merchdocs to devdocs. 

## Affected documentation pages

https://docs.magento.com/m2/ee/user_guide/stores/compliance-ccpa-guide.html

## Affected Magento editions

- [  x ] Open Source
- [  x ] Commerce
- [  x ] B2B
