### PR TITLE
Update Test Credit Card Link

### DIFF
--- a/src/payment/paypal-payments-standard.md
+++ b/src/payment/paypal-payments-standard.md
@@ -323,4 +323,4 @@ The Frontend Experience Settings give you the opportunity to choose which PayPal
 When complete, click <span class="btn">Save Config</span>.
 
 [1]: https://www.paypal.com/webapps/mpp/how-to-sell-online
-[2]: https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
+[2]: https://www.paypalobjects.com/en_GB/vhelp/paypalmanager_help/credit_card_numbers.htm


### PR DESCRIPTION
Available testing credit card details link provided in the document is no longer exist so I have change it to the new one.
I have replaced 
https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
Link with below link
https://www.paypalobjects.com/en_GB/vhelp/paypalmanager_help/credit_card_numbers.htm

## Purpose of this pull request

The paypal test card details link provided in the document is longer exist so I have changed it to new one. so any one can find out test card details easily from dev docs itself.

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on Open Source https://docs.magento.com/m2/ce/user_guide/ or Commerce or B2B. Not needed for large numbers of files. -->

- https://docs.magento.com/m2/ce/user_guide/payment/paypal-payments-standard.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [ ] B2B