### PR TITLE
Update Test Credit Card Link Payfort

### DIFF
--- a/src/payment/paypal-payflow-pro.md
+++ b/src/payment/paypal-payflow-pro.md
@@ -377,4 +377,4 @@ To better protect PayPal PayFlow Pro checkout, enable Google reCAPTCHA. It inclu
 
 [1]: https://www.paypal.com/webapps/mpp/how-to-sell-online
 [2]: https://manager.paypal.com/
-[3]: https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
+[3]: https://www.paypalobjects.com/en_GB/vhelp/paypalmanager_help/credit_card_numbers.htm


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

The paypal test card details link provided in the document is longer exist so I have changed it to new one. so any one can find out test card details easily from devdocs itself.

I have replaced
https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
Link with below link
https://www.paypalobjects.com/en_GB/vhelp/paypalmanager_help/credit_card_numbers.htm

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on Open Source https://docs.magento.com/m2/ce/user_guide/ or Commerce or B2B. Not needed for large numbers of files. -->

- https://docs.magento.com/m2/ce/user_guide/payment/paypal-payflow-pro.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [ ] B2B