### PR TITLE
Product Variation Attribute Input Types

### DIFF
--- a/src/catalog/product-create-configurable.md
+++ b/src/catalog/product-create-configurable.md
@@ -24,7 +24,7 @@ The properties of each attribute that is used for a configurable product variati
 |Property|Setting|
 |--- |--- |--- |
 |Scope|Global|
-[Catalog Input Type for Store Owner]({% link stores/attributes-product.md %})|The input type of any attribute that is used for a product variation must be one of the following: Dropdown, Visual, Text Swatch, or Swatch|
+[Catalog Input Type for Store Owner]({% link stores/attributes-product.md %})|The input type of any attribute that is used for a product variation must be one of the following: Dropdown, Visual Swatch, or Text Swatch.|
 |Values Required|Yes|
 
 ### Step 1: Choose the Product Type


### PR DESCRIPTION
#131  Purpose of this pull request

This PR corrects the valid input types for Catalog Input Type for Store Owner when setting up Configurable Product options.

## Affected documentation pages

[Configurable Product
](https://docs.magento.com/m2/ee/user_guide/catalog/product-create-configurable.html)

## Affected Magento editions

- [ x ] Open Source
- [ x ] Commerce
- [ x ] B2B
