### PR TITLE
Markdown linting: MD001 

### DIFF
--- a/_checks/styles/style-rules-prod
+++ b/_checks/styles/style-rules-prod
@@ -1,4 +1,4 @@
-exclude_rule 'MD001'
+rule 'MD001'
 exclude_rule 'MD002'
 exclude_rule 'MD003'
 exclude_rule 'MD004'

--- a/src/sales-channels/amazon/price-rule-examples.md
+++ b/src/sales-channels/amazon/price-rule-examples.md
@@ -4,7 +4,7 @@ title: Price Rule Examples
 
 ## Standard Price Rule Examples
 
-#### Discard Subsequent Rules
+### Discard Subsequent Rules
 
 The ability to discard subsequent rules is a great feature inside of pricing rules that prevents multiple pricing rules from stacking and providing unintended additional discounts. To discard subsequent rules, a pricing rule must use the priorities that are set in the Priority section.
 
@@ -20,7 +20,7 @@ For example, let’s say we have three pricing rules set up:
 
 In this scenario, rules #1 and #2 would apply to the eligible products. Rule #3 would only apply to eligible products not contained within Rule #2. This is because it has a lower priority than #2 and Discard Subsequent Rules is set to Yes. So, the eligible products in the sale category would receive 10% off and $2 off their Amazon listing price.
 
-#### Applying two standard price rules
+### Applying two standard price rules
 
 | Field | Setting - Rule 1 | Setting - Rule 2 |
 |----------|
@@ -53,7 +53,7 @@ The final price after Rule 1 and Rule 2 are applied: $32.98
 
 ## Intelligent Repricing Rule Examples
 
-#### Buy Box price with Floor Price Source = Price
+### Buy Box price with Floor Price Source = Price
 
 | Field | Setting |
 |----------|
@@ -85,7 +85,7 @@ Because the Buy Box price is greater than the original price, the product is lis
 
 The final price after the rule is applied: $10
 
-#### Buy Box price with Floor Price Source = Price and a 20% price decrease
+### Buy Box price with Floor Price Source = Price and a 20% price decrease
 
 | Field | Setting |
 |----------|
@@ -135,7 +135,7 @@ Because the Buy Box price is greater than the Calculated Floor Price, the produc
 
 The final price after the rule is applied: $15
 
-#### Lowest Price with All Competitor's Prices and Use all competitor's product conditions
+### Lowest Price with All Competitor's Prices and Use all competitor's product conditions
 
 | Field | Setting |
 |----------|
@@ -176,7 +176,7 @@ Because the lowest competitor price for the Used condition is $13, the product i
 
 The final price after the rule is applied: $13
 
-####  Intelligent repricing rule combining ceiling price, currency conversion, and VAT
+### Intelligent repricing rule combining ceiling price, currency conversion, and VAT
 
 | Field | Setting |
 |----------|
@@ -190,7 +190,7 @@ When the ceiling price in the European (VAT) market is hit, the VAT is calculate
 
 Final price after VAT: $12.50 x (1.1) = $13.75
 
-#### Combining multiple pricing rules, ceiling price, currency conversion, and VAT
+### Combining multiple pricing rules, ceiling price, currency conversion, and VAT
 
 **Intelligent pricing rule (from previous example):**
 
@@ -218,7 +218,7 @@ When the ceiling price is hit, the standard pricing rule will be applied on top 
 
 Final price after the standard pricing rule is applied: $13.75 + $5.00 = $18.75
 
-#### Price Adjustment
+### Price Adjustment
 
 In this example, we have chosen to define our most competitive price by looking at our Amazon competitor’s lowest price who also have 95% positive feedback and a minimum feedback count of 1,000 merchant reviews.
 
@@ -235,7 +235,7 @@ From here, we have three different Price Action choices based on this lowest pri
 |Apply|Options: Apply as percentage / Apply as fixed amount|
 |Adjustment Amount|Numerical value to define the percentage or fixed amount for the discount to be applied. <br/>These selections mean that we are going to take the lowest price and set ours $0.01 less.|
 
-#### Floor Price
+### Floor Price
 
 | Field | Setting |
 |----------|


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) addresses #325 

To address MD001: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md001---header-levels-should-only-increment-by-one-level-at-a-time

## Affected documentation pages

- https://docs.magento.com/m2/ee/user_guide/sales-channels/amazon/price-rule-examples.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B

