### PR TITLE
Corrected tables of Grouped and Configurable complex data

### DIFF
--- a/src/system/data-complex.md
+++ b/src/system/data-complex.md
@@ -19,14 +19,14 @@ _Exported Configurable Product Data_
 
 |Attribute|Description|
 |--- |--- |
-|associated_skus|Identifies the SKUs of the individual products that make up the group.|
+|configurable_variation_labels|Labels that identify product variations. For example: `Choose Color:` or `Choose Size:`|
+|configurable_variations|Describes the values associated with a product variation. For example: `sku=sku-red xs,color=red,size=xs,price=10.99,display=1,image=/pub/media/import/image1.png|sku=sku-red-m,color=red,size=m,price=20.88,display=1,image=/pub/media/import/image2.png`|
 
 ### Grouped Products
 
 |Attribute|Description|
 |--- |--- |
-|configurable_variation_labels|Labels that identify product variations. For example: `Choose Color:` or `Choose Size:`|
-|configurable_variations|Describes the values associated with a product variation. For example: `sku=sku-red xs,color=red,size=xs,price=10.99,display=1,image=/pub/media/import/image1.png|sku=sku-red-m,color=red,size=m,price=20.88,display=1,image=/pub/media/import/image2.png`|
+|associated_skus|Identifies the SKUs of the individual products that make up the group.|
 
 ### Bundle Products
 


### PR DESCRIPTION
## Purpose of this pull request

Swapped tables for complex data examples of configurable and grouped products to match labeling of headings; 



## Affected documentation pages

- https://docs.magento.com/m2/ee/user_guide/system/data-complex.html
- https://docs.magento.com/m2/ce/user_guide/system/data-complex.html
- https://docs.magento.com/m2/b2b/user_guide/system/data-complex.html

## Affected Magento editions

- [X] Open Source
- [X] Commerce
- [X] B2B

## Links to Magento source code or PRs


## Additional information


<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in a release integration branch.

See Contribution guidelines (https://github.com/magento/merchdocs/blob/master/.github/CONTRIBUTING.md) and wiki (https://github.com/magento/merchdocs/wiki) for more information.
-->
