### PR TITLE
Fix the link to Magento Keys information

### DIFF
--- a/src/design/theme-install.md
+++ b/src/design/theme-install.md
@@ -22,5 +22,5 @@ Follow the steps outlined in the [Marketplace Quick Tour][3], to:
 To apply the theme to your store, see: [Using the Default Theme]({% link design/theme-default.md %}).
 
 [1]: http://devdocs.magento.com/guides/v2.3/frontend-dev-guide/bk-frontend-dev-guide.html
-[2]: http://docs.magento.com/marketplace/user_guide/account/account-magento2-access-keys.html
+[2]: https://devdocs.magento.com/guides/v2.3/install-gde/prereq/connect-auth.html
 [3]: http://docs.magento.com/marketplace/user_guide/quick-tour/welcome.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request replaces the broken link with a working one, where a user can find an instruction how to create Magento 2 Access Keys.

## Affected documentation pages
https://docs.magento.com/m2/ee/user_guide/design/theme-install.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B

## Additional information

Fixes #247 

