### PR TITLE
Markdown linting: MD006

### DIFF
--- a/_checks/styles/style-rules-prod
+++ b/_checks/styles/style-rules-prod
@@ -3,7 +3,7 @@ exclude_rule 'MD002'
 rule 'MD003', :style => :atx # Header style
 rule 'MD004' # Unordered list style, default "consistent"
 rule 'MD005' # inconsistent indentation for list items at the same level
-exclude_rule 'MD006'
+rule 'MD006' # consider starting bulleted lists at the beginning of the line
 exclude_rule 'MD007'
 rule 'MD009' # no trailing spaces
 exclude_rule 'MD010'

--- a/src/design/design-menu.md
+++ b/src/design/design-menu.md
@@ -18,7 +18,9 @@ _Design Menu_
 {:.procedure}
 To display the Design menu:
 
-  - On the _Admin_ sidebar, select **Content**. The Design options are part of the Content menu.
+- On the _Admin_ sidebar, select **Content**.
+
+  The Design options are part of the Content menu.
 
 ## Menu Options
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) addresses #329 

To address MD006:
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md006---consider-starting-bulleted-lists-at-the-beginning-of-the-line

**_Note:_** Fix for MD005 already addressed most of the original items for this rule. 

## Affected documentation pages

https://docs.magento.com/m2/ee/user_guide/design/design-menu.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B

