### PR TITLE
Remove Marketplace User Guide from federated search

### DIFF
--- a/src/_includes/layout/header-scripts.html
+++ b/src/_includes/layout/header-scripts.html
@@ -19,11 +19,6 @@
       baseUrl: "https://docs.magento.com/mbi"
     },
     {
-      label: "Marketplace User Guide",
-      name: "merchdocs-marketplace",
-      baseUrl: "https://docs.magento.com/marketplace/user_guide"
-    },
-    {
       label: "DevDocs",
       name: "devdocs",
       facetFilters: [["guide_version: 2.3", "versionless: true"]],


### PR DESCRIPTION
## Purpose of this pull request

With the migration of Marketplace User Guide content to DevDocs and the Magento User Guide, it should not be a property in the federated search. 

## Affected documentation pages

N/A

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B

