### PR TITLE
Update ups.md

### DIFF
--- a/src/shipping/ups.md
+++ b/src/shipping/ups.md
@@ -73,7 +73,6 @@ To offer this shipping method to your customers, you must first open an account 
 
     | Residential | Most of your shipments are business to consumer (B2C). |
     | Commercial | Most of your shipments are business to business (B2B). |
-    | Define Automatically | UPS determines the destination as either residential or commercial, and uses the appropriate rate from the merchant’s UPS account. |
 
 1. Enter the **Maximum Package Weight** allowed by the carrier.
 


### PR DESCRIPTION
## Purpose of this pull request

For the UPS shipping configuration, the "Destination Type" has only two options.
We should remove the "Define Automatically" option from this devdocs. There was a jira ticket to add this option, https://jira.corp.magento.com/browse/MAGETWO-7992, but for some reason it was cancelled.

This pull request (PR) removes the unavailable option.

## Affected documentation pages

- https://docs.magento.com/m2/ee/user_guide/shipping/ups.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B

## Additional information

