### PR TITLE
Fix placement of condition under table

### DIFF
--- a/src/configuration/advanced/admin.md
+++ b/src/configuration/advanced/admin.md
@@ -91,8 +91,8 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Adva
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |
 |Enable Actions|Global|Enables action logging for each of the selected actions: <br/>Admin My Account <br/>Admin Permission Roles <br/>Admin Permission Users <br/>Admin Sign In <br/>CMS Blocks <br/>CMS Hierarchy <br/>CMS Pages <br/>Cache Management <br/>Catalog Attributes <br/>Catalog Categories <br/>Catalog Events <br/>Catalog Price Rules <br/>Catalog Product Tax Classes <br/>Catalog Product Templates <br/>Catalog Products <br/>Catalog Ratings <br/>Catalog Reviews <br/>Catalog Search <br/>Checkout Terms and Conditions <br/>Custom Variables <br/>Customer Groups <br/>Customer Invitations <br/>Customer Tax Classes <br/>Customers <br/>Gift Card Accounts <br/>Gift Registry Entity <br/>Gift Registry Type <br/>Index Management <br/>Manage Currency Rates <br/>Manage Customer Address Attributes <br/>Manage Customer Attributes <br/>Manage Design <br/>Manage Dynamic Blocks <br/>Manage Segments <br/>Manage Store Views <br/>Manage Stores <br/>Manage Websites <br/>Newsletter Queue <br/>Newsletter Subscribers <br/>Newsletter Templates <br/>PayPal Settlement Reports <br/>Reports <br/> Reward Points Rates <br/>Rule-Based Product Relations <br/>Sales Archive <br/>Sales Credit Memos <br/>Sales Invoices <br/>Sales Order Status <br/>Sales Orders <br/>Sales Shipments <br/>Shopping Cart Management <br/>Store Credit <br/>System Backups <br/>System Configuration <br/>Tax Rates <br/>Tax Rules <br/>Transactional Emails <br/>URL Rewrites <br/>Widget <br/>XML Sitemap|
-<!--{% endif %}-->
 
+<!--{% endif %}-->
 ## Admin Usage
 
 ![Admin Usage]({% link images/images/config-advanced-admin-usage.png %}){: .zoom}


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the issue with the table displayed in the Admin Actions Logging section (#433 ).

The condition ending statement is directly below the table, which causes a rendering error. Moved it above the next section heading with a blank line after the table.

## Affected documentation pages

- https://docs.magento.com/m2/ee/user_guide/configuration/advanced/admin.html#admin-actions-logging

## Affected Magento editions

- [ ] Open Source
- [x] Commerce
- [x] B2B
