### PR TITLE
Change log updates for 2.3.5, deprecate Signifyd

### DIFF
--- a/src/_data/b2b/toc/sales.yml
+++ b/src/_data/b2b/toc/sales.yml
@@ -293,7 +293,7 @@ pages:
   - label: Fraud Protection
     url: "/sales/fraud-protection.html"
     children:
-    - label: Signifyd
+    - label: Signifyd Fraud Protection - Deprecated
       url: "/sales/fraud-protection-signifyd.html"
 - label: Shipping
   url: "/shipping/shipping.html"

--- a/src/_data/ce/toc/sales.yml
+++ b/src/_data/ce/toc/sales.yml
@@ -225,7 +225,7 @@ pages:
   - label: Fraud Protection
     url: "/sales/fraud-protection.html"
     children:
-    - label: Signifyd Fraud Protection
+    - label: Signifyd Fraud Protection - Deprecated
       url: "/sales/fraud-protection-signifyd.html"
 - label: Shipping
   url: "/shipping/shipping.html"

--- a/src/_data/ee/toc/sales.yml
+++ b/src/_data/ee/toc/sales.yml
@@ -265,7 +265,7 @@ pages:
   - label: Fraud Protection
     url: "/sales/fraud-protection.html"
     children:
-    - label: Signifyd
+    - label: Signifyd Fraud Protection - Deprecated
       url: "/sales/fraud-protection-signifyd.html"
 - label: Shipping
   url: "/shipping/shipping.html"

--- a/src/magento/change-log.md
+++ b/src/magento/change-log.md
@@ -36,7 +36,7 @@ Our documentation is continually updated with new topics, clarifications, and co
 |[Banner]({% link cms/page-builder-media-banner.md %})<br/>[Row]({% link cms/page-builder-layout-row.md %})<br/>[Slider]({% link cms/page-builder-media-slider.md %})|Updated content for new _Minimum Height_ option and support for full-height functionality. Additional content for new video background feature.|
 |[Video]({% link cms/page-builder-media-video.md %})|Additional content for new _Autoplay_ feature.|
 |[Worldpay - Deprecated]({% link payment/worldpay.md %})|Updated information for deprecation status.|<!--{% endif %}-->
-|[Signifyd Guaranteed Fraud Protection]({% link payment/worldpay.md %})|Added important note for deprecated status and transitioning from this integration to a Marketplace extension.|
+|[Signifyd Guaranteed Fraud Protection]({% link sales/fraud-protection-signifyd.md %})|Added important note for deprecated status and transitioning from this integration to a Marketplace extension.|
 
 ## March 2020
 

--- a/src/magento/change-log.md
+++ b/src/magento/change-log.md
@@ -4,6 +4,40 @@ title: Change Log
 
 Our documentation is continually updated with new topics, clarifications, and corrections to existing content. Learn more about new features, major updates, and releases, organized by month and year. Check back every now and then to see what’s new.
 
+## April 2020
+
+### Product releases
+
+<!--{% if "Default.B2B Only" contains site.edition %}-->
+- [Magento for B2B Commerce](https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.5Commerce.html){: target="_blank"}, pre-release 2.3.5
+<!--{% endif %}-->
+<!--{% if "Default.EE Only" contains site.edition %}-->
+- [Magento Commerce](https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.5Commerce.html){: target="_blank"}, pre-release 2.3.5
+<!--{% endif %}-->
+<!--{% if "Default.CE Only" contains site.edition %}-->
+- [Magento Open Source](https://devdocs.magento.com/guides/v2.3/release-notes/ReleaseNotes2.3.5OpenSource.html){: target="_blank"}, pre-release 2.3.5
+<!--{% endif %}-->
+<!--{% if "Default.EE-B2B" contains site.edition %}-->
+- [Page Builder](https://devdocs.magento.com/page-builder/docs/release-notes.html){: target="_blank"}, 1.3
+<!--{% endif %}-->
+- [Inventory Management](https://devdocs.magento.com/guides/v2.3/inventory/release-notes.html){:target="_blank"}, 1.1.4
+
+<!--{% if "Default.EE-B2B" contains site.edition %}-->
+### New topics
+
+- [Templates]({% link cms/page-builder-templates.md %})
+<!--{% endif %}-->
+
+### Updated topics
+
+|Topic |Change|
+|--- |--- |
+|[Configure Global Options]({% link catalog/inventory-options-global.md %})|Added information for the new _Synchronize with Catalog_ option provided by Inventory Management. |<!--{% if "Default.EE-B2B" contains site.edition %}-->
+|[Banner]({% link cms/page-builder-media-banner.md %})<br/>[Row]({% link cms/page-builder-layout-row.md %})<br/>[Slider]({% link cms/page-builder-media-slider.md %})|Updated content for new _Minimum Height_ option and support for full-height functionality. Additional content for new video background feature.|
+|[Video]({% link cms/page-builder-media-video.md %})|Additional content for new _Autoplay_ feature.|
+|[Worldpay - Deprecated]({% link payment/worldpay.md %})|Updated information for deprecation status.|<!--{% endif %}-->
+|[Signifyd Guaranteed Fraud Protection]({% link payment/worldpay.md %})|Added important note for deprecated status and transitioning from this integration to a Marketplace extension.|
+
 ## March 2020
 
 ### Product releases

--- a/src/sales/fraud-protection-signifyd.md
+++ b/src/sales/fraud-protection-signifyd.md
@@ -1,6 +1,10 @@
 ---
-title: Signifyd Guaranteed Fraud Protection
+title: Signifyd Guaranteed Fraud Protection - Deprecated
 ---
+
+{:.bs-callout-warning}
+**Deprecation Notice** <br/>
+Due to the continued evolution of many APIs, this fraud protection integration is at risk of becoming outdated and no longer security compliant in the future. For this reason, it is now deprecated and we are recommending that you disable it in your Magento configuration and transition to the [Signifyd Fraud & Chargeback Protection extension](https://marketplace.magento.com/signifyd-module-connect.html){:target="_blank"} that is available on Magento Marketplace.
 
 Signifyd Guaranteed Fraud Protection automates your order review process so you can accept more orders and maximize revenue without chargeback losses. Signifyd automatically reviews orders for fraud, and indicates which orders to ship, and which to reject. The results of the Signifyd Guarantee Decision appear as a column in the [Orders]({% link sales/orders.md %}) grid.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds new section to the Change Log for the 2.3.5 release and new/updated topics for completed PRs. 

Update to the Signifyd integration for deprecated status. (Will be removed in 2.4)

## Affected documentation pages

- https://docs.magento.com/m2/ee/user_guide/magento/change-log.html
- https://docs.magento.com/m2/ee/user_guide/sales/fraud-protection-signifyd.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B
