### PR TITLE
Inventory: Add support for bundle products

### DIFF
--- a/src/catalog/inventory-about-product-types.md
+++ b/src/catalog/inventory-about-product-types.md
@@ -9,17 +9,11 @@ Inventory Management supports inventory and order management for all product typ
 - Multi Source merchants assign sources, quantities per source, and settings during or after product creation. Magento assigns all newly imported products to the Default Source, requiring additional edits to assign sources and quantities.
 
 {: .list-table }
-|Product Type|Single Source|Multi Source|Source and Stock|Shipping and Source Selection Algorithm|
-|--|--|--|--|--|
-|[Simple]({% link catalog/product-create-simple.md %})|Yes|Yes|Default Source<br/>Default Stock<br/>custom source/stock|Supports SSA recommendations and overrides at shipping|
-|[Configurable]({% link catalog/product-create-configurable.md %})|Yes|Yes|Default Source<br/>Default Stock<br/>custom source/stock|Supports SSA recommendations and overrides at shipping|
-|[Virtual]({% link catalog/product-create-virtual.md %})|Yes|Yes|Default Source<br/>Default Stock<br/>custom source/stock|Always uses the SSA recommendation. The system runs the algorithm implicitly when it creates invoices, and always uses the suggested results.<br/>You cannot adjust these results.|
-|[Downloadable]({% link catalog/product-create-downloadable.md %})|Yes|Yes|Default Source<br/>Default Stock<br/>custom source/stock|Always uses the SSA recommendation. The system runs the algorithm implicitly when it creates invoices, and always uses the suggested results. <br/>You cannot adjust these results.|
-|[Bundle]({% link catalog/product-create-bundle.md %})|Yes|No|Default Source<br/>Default Stock|Supports SSA recommendations and overrides at shipping|
-|[Grouped]({% link catalog/product-create-grouped.md %})|Yes|Yes|Default Source<br/>Default Stock<br/>custom source/stock|Supports SSA recommendations and overrides at shipping|
-
-<style>
-.list-table td:nth-of-type(4) {
-  width: 200px;
-}
-</style>
+|Product Type|Shipping and Source Selection Algorithm|
+|--|--|
+|[Simple]({% link catalog/product-create-simple.md %})|Supports SSA recommendations and overrides at shipping|
+|[Configurable]({% link catalog/product-create-configurable.md %})|Supports SSA recommendations and overrides at shipping|
+|[Virtual]({% link catalog/product-create-virtual.md %})|Always uses the SSA recommendation. The system runs the algorithm implicitly when it creates invoices, and always uses the suggested results.<br/>You cannot adjust these results.|
+|[Downloadable]({% link catalog/product-create-downloadable.md %})|Always uses the SSA recommendation. The system runs the algorithm implicitly when it creates invoices, and always uses the suggested results. <br/>You cannot adjust these results.|
+|[Bundle]({% link catalog/product-create-bundle.md %})|Supports SSA recommendations and overrides at shipping|
+|[Grouped]({% link catalog/product-create-grouped.md %})|Supports SSA recommendations and overrides at shipping|

--- a/src/catalog/product-create-bundle.md
+++ b/src/catalog/product-create-bundle.md
@@ -136,6 +136,9 @@ _Choose Template_
     ![]({% link images/images/product-bundle-items.png %}){: .zoom}
     _Bundle Items_
 
+    If you select `Together` and have enabled In-Store Delivery, all bundle items must be assigned the same [source]({% link catalog/inventory-sources.md %}).
+    <!-- Add link to In-Store Delivery when the topic is added -->
+
 1. Click <span class="btn">Add Option</span> and do the following:
 
     ![]({% link images/images/product-bundle-new-option.png %}){: .zoom}


### PR DESCRIPTION
## Purpose of this pull request

Previously, bundle products were the only type of product that Inventory Management did not support. As of 2.4, this is no longer the case. 

The table in "About Product Types" was reduced from 5 columns to 2 because there is no longer a need to differentiate bundle products from the other product types.

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on Open Source https://docs.magento.com/m2/ce/user_guide/ or Commerce or B2B. Not needed for large numbers of files. -->

- https://docs.magento.com/m2/ee/user_guide/catalog/inventory-about-product-types.html
- https://docs.magento.com/m2/ee/user_guide/catalog/product-create-bundle.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B

## Links to Magento source code or PRs

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository or a code PR, add it here. -->

- ...
- ...

## Additional information

<!-- (OPTIONAL) What other information can you provide? -->

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in a release integration branch.

See Contribution guidelines (https://github.com/magento/merchdocs/blob/master/.github/CONTRIBUTING.md) and wiki (https://github.com/magento/merchdocs/wiki) for more information.
-->
