### PR TITLE
Markdown linting: MD018 and MD019

### DIFF
--- a/_checks/styles/style-rules-dev
+++ b/_checks/styles/style-rules-dev
@@ -6,13 +6,13 @@ rule 'MD005' # inconsistent indentation for list items at the same level
 rule 'MD006' # consider starting bulleted lists at the beginning of the line
 rule 'MD007', :indent => 3 # unordered list indentation
 rule 'MD009' # no trailing spaces
-rule 'MD010'
+rule 'MD010' # hard tabs
 exclude_rule 'MD011'
-rule 'MD012'
+rule 'MD012' # multiple consecutive blank lines
 exclude_rule 'MD013'
 exclude_rule 'MD014'
-exclude_rule 'MD018'
-exclude_rule 'MD019'
+rule 'MD018' # no space after hash on atx style header
+rule 'MD019' # multiple spaces after hash on atx style header
 exclude_rule 'MD020'
 exclude_rule 'MD021'
 exclude_rule 'MD022'

--- a/_checks/styles/style-rules-prod
+++ b/_checks/styles/style-rules-prod
@@ -6,13 +6,13 @@ rule 'MD005' # inconsistent indentation for list items at the same level
 rule 'MD006' # consider starting bulleted lists at the beginning of the line
 rule 'MD007', :indent => 3 # unordered list indentation
 rule 'MD009' # no trailing spaces
-rule 'MD010'
+rule 'MD010' # hard tabs
 exclude_rule 'MD011'
-rule 'MD012'
+rule 'MD012' # multiple consecutive blank lines
 exclude_rule 'MD013'
 exclude_rule 'MD014'
-exclude_rule 'MD018'
-exclude_rule 'MD019'
+rule 'MD018' # no space after hash on atx style header
+rule 'MD019' # multiple spaces after hash on atx style header
 exclude_rule 'MD020'
 exclude_rule 'MD021'
 exclude_rule 'MD022'

--- a/src/cms/dynamic-blocks.md
+++ b/src/cms/dynamic-blocks.md
@@ -63,7 +63,7 @@ _Page Builder Workspace_
 
 1. Use the [Add Dynamic Block]({% link cms/page-builder-add-dynamic-block.md %}) content type to add the dynamic block to the stage.
 
-##  Field Descriptions
+## Field Descriptions
 
 |Field|Description|
 |--- |--- |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) addresses #334 

To address MD018:
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md018---no-space-after-hash-on-atx-style-header

To address MD019:
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md019---multiple-spaces-after-hash-on-atx-style-header

## Affected documentation pages

No change to content

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B
