### PR TITLE
Add Note about Timestamp usage

### DIFF
--- a/src/cms/content-staging-scheduled-update.md
+++ b/src/cms/content-staging-scheduled-update.md
@@ -29,6 +29,9 @@ The following example shows how to schedule a temporary price change for a produ
     ![]({% link images/images-ee/content-staging-campaign-schedule-update.png %}){: .zoom}
     _Scheduling a Product Update_
 
+    {:.bs-callout-info}
+    Date/Time have to be always in timezone of appropriate Website. For example, if you have multiple Websites in different timezones, but you want to start campaign based on US time, you need to schedule an update for each Website separately and define date/time in local time. 
+
 1. Scroll down to the **Price** field and click **Advanced Pricing**.
 
 1. Enter a **Special Price** for the product during the scheduled campaign. Then, click <span class="btn">Done</span>.


### PR DESCRIPTION
## Purpose of this pull request
I am adding notes about timezones usage while scheduling content.
It costed us couple of hours with customer on a lint for detect a problem with scheduling, so I guess it make sense to have it here.

## Affected documentation pages

https://docs.magento.com/m2/ee/user_guide/cms/content-staging-scheduled-update.html

## Affected Magento editions

- [ ] Open Source
- [x] Commerce
- [ ] B2B

