### PR TITLE
Markdown linting: MD023

### DIFF
--- a/_checks/styles/style-rules-dev
+++ b/_checks/styles/style-rules-dev
@@ -16,7 +16,7 @@ rule 'MD019' # multiple spaces after hash on atx style header
 exclude_rule 'MD020'
 exclude_rule 'MD021'
 exclude_rule 'MD022'
-exclude_rule 'MD023'
+rule 'MD023' # headers must start at the beginning of the line
 exclude_rule 'MD024'
 exclude_rule 'MD025'
 exclude_rule 'MD026'

--- a/_checks/styles/style-rules-prod
+++ b/_checks/styles/style-rules-prod
@@ -16,7 +16,7 @@ rule 'MD019' # multiple spaces after hash on atx style header
 exclude_rule 'MD020'
 exclude_rule 'MD021'
 exclude_rule 'MD022'
-exclude_rule 'MD023'
+rule 'MD023' # headers must start at the beginning of the line
 exclude_rule 'MD024'
 exclude_rule 'MD025'
 exclude_rule 'MD026'

--- a/src/payment/paypal-credit.md
+++ b/src/payment/paypal-credit.md
@@ -10,17 +10,19 @@ Give your sales a boost when you advertise financing. PayPal helps turn browsers
 
 You can easily add free, ready-made banner ads to pages of your site, and the PayPal Credit button to your shopping cart during checkout to remind your customers that financing is readily available.
 
-**Payment Options that can use PayPal Credit**
+## Payment options that can use PayPal Credit
 
-For US merchants, PayPal Credit is enabled by default for the [PayPal Express Checkout]({% link payment/paypal-express-checkout.md %}) payment option. To disable it for this payment option, see the **Features** section of [PayPal Express Checkout]({% link payment/paypal-express-checkout.md %}) configuration.
+For US merchants, PayPal Credit is enabled by default for the [PayPal Express Checkout]({% link payment/paypal-express-checkout.md %}) payment option. To disable it for this payment option, see the _Features_ section of PayPal Express Checkout configuration.
 
-For the following **Other PayPal Payment Solutions**, PayPal Credit is disabled by default but can be enabled in the payment option's configuration. See each option's configuration to enable PayPal Credit:
-   - [Payments Advanced]({% link payment/paypal-payments-advanced.md %})
-   - [Payments Pro]({% link payment/paypal-payments-pro.md %})
-   - [Payments Standard]({% link payment/paypal-payments-standard.md %})
-   - [Payflow Pro]({% link payment/paypal-payflow-pro.md %})
-   - [Payflow Link]({% link payment/paypal-payflow-link.md %})
+PayPal Credit is disabled by default for these _Other PayPal Payment Solutions_, but can be enabled in the payment option configuration:
 
-Before you configure PayPal Credit for your Magento store, make sure it is enabled in your PayPal Merchant Account.
+- [Payments Advanced]({% link payment/paypal-payments-advanced.md %})
+- [Payments Pro]({% link payment/paypal-payments-pro.md %})
+- [Payments Standard]({% link payment/paypal-payments-standard.md %})
+- [Payflow Pro]({% link payment/paypal-payflow-pro.md %})
+- [Payflow Link]({% link payment/paypal-payflow-link.md %})
+
+{:.bs-callout-info}
+**Important:** Before you configure PayPal Credit for your Magento store, make sure it is enabled in your PayPal Merchant Account.
 
 [1]: https://www.paypal.com/us/webapps/mpp/promotional-financing


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) addresses #339 

To address MD023:
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md023---headers-must-start-at-the-beginning-of-the-line

Only one file had violations. Also did some editing for other style consistencies as long as I was in there. 

## Affected documentation pages

- docs.magento.com/m2/ee/user_guide/payment/paypal-credit.html

## Affected Magento editions

- [x] Open Source
- [x] Commerce
- [x] B2B
