### PR TITLE
Fix the github link to point to the right source page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ defaults:
       github_link: true
       feedback_link: true
       github_repo: https://github.com/magento/merchdocs/
-      github_files: https://github.com/magento/merchdocs/blob/master/src/
+      github_files: https://github.com/magento/merchdocs/blob/master/
 
   -
     scope:

--- a/_plugins/github-path.rb
+++ b/_plugins/github-path.rb
@@ -1,0 +1,33 @@
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
+
+# frozen_string_literal: true
+
+#
+# This custom plugin dynamically sets the 'github_path' parameter
+# for each page except 'redirect.html' pages.
+# A value of the parameter is available as {{ page.github_path }}.
+# The parameter contains a file path relative to its repository.
+#
+Jekyll::Hooks.register :pages, :post_init do |page|
+
+  # Skip virtual pages like MRG topics
+  next if page.kind_of? Jekyll::PageWithoutAFile
+  # Process only files with 'md' and 'html' extensions
+  next unless File.extname(page.path).match?(/md|html/)
+  # Skip redirects
+  next if page.name == 'redirect.html'
+
+  dir = File.join(
+    page.site.source,
+    File.dirname(page.path)
+  )
+  
+  filename = File.basename page.path
+
+  # Change to the parent directory of the page and read full file path
+  # from git index.
+  Dir.chdir(dir) do
+    page.data['github_path'] = `git ls-files --full-name #{filename}`.strip
+  end
+end


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) fixes the Edit on Github link not pointing to the right source page.

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- all

## Links to Magento source code or PRs

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository or a code PR, add it here. -->

- ...
- ...

## Additional information

<!-- OPTIONAL - REMOVE THIS SECTION IF NOT USED. What other information can you provide? -->

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in a release integration branch.

See Contribution guidelines (https://github.com/magento/merchdocs/blob/master/.github/CONTRIBUTING.md) and wiki (https://github.com/magento/merchdocs/wiki) for more information.
-->
