### PR TITLE
fixed typo: whee to where

### DIFF
--- a/src/marketing/search-synonyms.md
+++ b/src/marketing/search-synonyms.md
@@ -21,7 +21,7 @@ _Search Results_
     ![New search synonyms group]({% link images/images/search-synonym-group-new.png %}){: .zoom}
     _New Synonym Group_
 
-   - Set **Scope** to the store views whee the synonyms apply.
+   - Set **Scope** to the store views where the synonyms apply.
 
    - Enter each synonym in the group, separated by comma. Choose words that people might use as search criteria. For example:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) corrects a reported typo of "whee" to "where".

If Magento Commerce, please specify:

- [ ] Commerce only?
- [ ] Commerce with B2B?

## Affected documentation pages

- https://docs.magento.com/user-guide/marketing/search-synonyms.html

## Additional information

Issue reported to me in slack, used the Edit this page option.
