### PR TITLE
Adding link to Page Builder install page

### DIFF
--- a/src/marketing/page-builder-add-product-recs.md
+++ b/src/marketing/page-builder-add-product-recs.md
@@ -6,7 +6,7 @@ title: Add Product Recommendations
 Use the Product Recommendations content type to add an existing, active [recommendation unit]({% link marketing/create-new-rec.md %}) to a page, block, or dynamic block.
 
 {:.bs-callout-info}
-The Product Recommendations content type in Page Builder is supported in Magento 2.3.1 and later and available in the [Product Recommendations metapackage versions 3.0.x or later](https://marketplace.magento.com/magento-product-recommendations.html).
+The Product Recommendations content type in Page Builder is supported in Magento 2.3.1 and later and available in the [Product Recommendations metapackage versions 3.0.x or later](https://marketplace.magento.com/magento-product-recommendations.html). To add Page Builder support, [see the developer documentation](https://devdocs.magento.com/recommendations/install-configure.html#pbsupport).
 
 ## Add an existing recommendation unit
 

--- a/src/marketing/product-recommendations.md
+++ b/src/marketing/product-recommendations.md
@@ -9,7 +9,7 @@ Product recommendations are a powerful marketing tool you can use to increase co
 You can create, manage, and deploy recommendations across your store views directly from the Magento Admin panel.
 
 {:.bs-callout-info}
-For information about how to install the product recommendations module so you can begin collecting shopper behavior and catalog data, refer to the [developer documentation](https://devdocs.magento.com/recommendations/install.html).
+For information about how to install the product recommendations module so you can begin collecting shopper behavior and catalog data, refer to the [developer documentation](https://devdocs.magento.com/recommendations/install-configure.html).
 
 ## Dashboard {#dashboard}
 

--- a/src/marketing/product-recommendations.md
+++ b/src/marketing/product-recommendations.md
@@ -9,7 +9,7 @@ Product recommendations are a powerful marketing tool you can use to increase co
 You can create, manage, and deploy recommendations across your store views directly from the Magento Admin panel.
 
 {:.bs-callout-info}
-For information about how to install the product recommendations module so you can begin collecting shopper behavior and catalog data, refer to the [developer documentation](https://devdocs.magento.com/recommendations/install-configure.html).
+For information about installing product recommendations modules, refer to the [developer documentation](https://devdocs.magento.com/recommendations/install-configure.html).
 
 ## Dashboard {#dashboard}
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) adds a link to the Page Builder support install page in devdocs.

If Magento Commerce, please specify:

- [x] Commerce only?
- [ ] Commerce with B2B?

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/marketing/product-recommendations.html