### PR TITLE
Deprecate native Braintree integration

### DIFF
--- a/src/configuration/sales/braintree.md
+++ b/src/configuration/sales/braintree.md
@@ -5,8 +5,9 @@ title: Braintree
 Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Sales]({% link configuration/sales.md %}) > [Payment Methods]({% link configuration/sales/payment-methods.md %}) > Braintree
 
 {:.bs-callout-warning}
-**Payment Services Directive Requirements:** <br/>
-As of September 14, 2019, European banks might decline payments that do not meet [PSD2]({% link stores/compliance-payment-services-directive.md %}) requirements. Starting with Magento ver. 2.2.3, Braintree provides native support for 3D Secure 2.0.<br/>To meet PSD2 requirements for earlier versions of Magento, install and configure the official Braintree payment integration extension from [Magento Marketplace](https://marketplace.magento.com/catalogsearch/result/?q=braintree). Older Braintree implementations that run on JavaScript SDK v2 do not support 3D Secure 2.0.
+**Deprecation Notice** <br/>
+Due to the Payment Service Directive [PSD2]({% link stores/compliance-payment-services-directive.md %}) and the continued evolution of many APIs, this payment integration is at risk of becoming outdated and no longer security compliant. For this reason, it is now deprecated and we are recommending that you disable it in your Magento 2.3.x configuration and transition to the official Braintree payment extension from [Magento Marketplace](https://marketplace.magento.com/catalogsearch/result/?q=braintree). <br/><br/>
+**This integration has been deprecated from current versions of 2.3.x.**<br/><br/>
 
 ## Basic Braintree Settings
 

--- a/src/payment/braintree.md
+++ b/src/payment/braintree.md
@@ -3,8 +3,9 @@ title: Braintree
 ---
 
 {:.bs-callout-warning}
-**Payment Services Directive Requirements:** <br/>
-As of September 14, 2019, European banks might decline payments that do not meet [PSD2]({% link stores/compliance-payment-services-directive.md %}) requirements. Starting with Magento ver. 2.2.3, Braintree provides native support for 3D Secure 2.0.<br/>To meet PSD2 requirements for earlier versions of Magento, install and configure the official Braintree payment integration extension from [Magento Marketplace](https://marketplace.magento.com/catalogsearch/result/?q=braintree). Older Braintree implementations that run on JavaScript SDK v2 do not support 3D Secure 2.0.
+**Deprecation Notice** <br/>
+Due to the Payment Service Directive [PSD2]({% link stores/compliance-payment-services-directive.md %}) and the continued evolution of many APIs, this payment integration is at risk of becoming outdated and no longer security compliant. For this reason, it is now deprecated and we are recommending that you disable it in your Magento 2.3.x configuration and transition to the official Braintree payment extension from [Magento Marketplace](https://marketplace.magento.com/catalogsearch/result/?q=braintree). <br/><br/>
+**This integration has been deprecated from current versions of 2.3.x.**<br/><br/>
 
 Braintree offers a fully customizable checkout experience with fraud detection and PayPal integration. Braintree reduces the PCI compliance burden for merchants because the transaction takes place on the Braintree system.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds messaging for deprecation of the core Braintree integration for 2.3.x so that customers will not expect us to maintain this code going forward and will know to switch to the Marketplace extension for 2.3.x. This will become a VBE for 2.4.0.

If Magento Commerce, please specify:

- [ ] Commerce only?
- [ ] Commerce with B2B?

## Affected documentation pages

- https://docs.magento.com/user-guide/payment/braintree.html
- https://docs.magento.com/user-guide/configuration/sales/braintree.html
