### PR TITLE
2.3 GitHub edit page link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,7 @@ defaults:
       github_link: true
       feedback_link: true
       github_repo: https://github.com/magento/merchdocs/
-      github_files: https://github.com/magento/merchdocs/blob/master/
+      github_files: https://github.com/magento/merchdocs/blob/2.3-production/
 
   -
     scope:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes the "Edit on GitHub" link in the 2.3 User Guide to go to the 2.3-production branch.

Many pages were removed in 2.4 and if the link is master it will not resolve for those pages and results in a 404. Also, for pages that are modified in 2.4, the source in master will not match the 2.3 published page.  

## Magento release version

- [ ] 2.4.x

   Specify a patch release number, if applicable:

- [x] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

All pages in 2.3 guide: https://docs.magento.com/user-guide/v2.3/

If you test this page and click the "Edit on GitHub" link it will go to a GitHub 404 page: https://docs.magento.com/user-guide/v2.3/shipping/magento-shipping.html


