### PR TITLE
Update self-service-tools.md

### DIFF
--- a/src/quick-tour/self-service-tools.md
+++ b/src/quick-tour/self-service-tools.md
@@ -16,7 +16,7 @@ Payments On Account
 :  Allow companies to make [purchases charged to their account]({% link payment/payment-on-account.md %}), up to the credit limit that is specified in their profile.
 
 Negotiated Quotes
-:  Company buyers can [request a quote]({% link sales/quote-request.md %}) from the shopping cart, and then negotiate with the seller to reach a acceptable price per line item.
+:  Company buyers can [request a quote]({% link sales/quote-request.md %}) from the shopping cart, and then negotiate with the seller to reach an acceptable price per line item.
 
 Quote Tracking
 :  A detailed history of all [activity related to quotes]({% link customers/account-dashboard-quotes.md %}), including all interactions between buyer and seller during the negotiation process, is available from the company’s account and from the store’s back office Admin.


### PR DESCRIPTION
“an” is used before words starting with vowel sounds.

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) fixes a missing letter "n". “an” is used before words starting with vowel sounds.


## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/quick-tour/self-service-tools.html

