### PR TITLE
MC-36350: Update documentation about Adjustment Refund option on Cred…

### DIFF
--- a/src/sales/credit-memo-create.md
+++ b/src/sales/credit-memo-create.md
@@ -74,7 +74,7 @@ _Create Credit Memo_
 
       This field initially shows the total shipping amount from the order that is available for refund. It is equal to the full shipping amount from the order, less any shipping amount that has already been refunded. Like the quantity, the amount can be reduced, but not increased.
 
-   - For **Adjustment Refund**, enter a value to be added to the total amount refunded as an additional refund that does not apply to any particular part of the order (shipping, items, or tax). It also can be used for partial refund with virtual money like Gift Card when an administrator wants to refund a non-virtual payment method first.
+   - For **Adjustment Refund**, enter a value to be added to the total amount refunded as an additional refund that does not apply to any particular part of the order (shipping, items, or tax). It also can be used for partial refund with virtual money, such as a gift card, when an administrator wants to refund a non-virtual payment method first.
 
       The amount entered cannot raise the total refund higher than the paid amount.
 
@@ -135,7 +135,7 @@ _Create Credit Memo_
 
       This field initially displays the total shipping amount from the order that is available for refund. It is equal to the full shipping amount from the order, less any shipping amount that has already been refunded. Like the quantity, the amount can be reduced, but not increased.
 
-   - For **Adjustment Refund**, enter a value to be added to the total amount refunded as an additional refund that does not apply to any particular part of the order (shipping, items, or tax). It also can be used for partial refund with virtual money like Gift Card when an administrator wants to refund a non-virtual payment method first.
+   - For **Adjustment Refund**, enter a value to be added to the total amount refunded as an additional refund that does not apply to any particular part of the order (shipping, items, or tax). It also can be used for partial refund with virtual money, such as a gift card, when an administrator wants to refund a non-virtual payment method first.
 
       The amount entered cannot raise the total refund higher than the paid amount.
 

--- a/src/sales/credit-memo-create.md
+++ b/src/sales/credit-memo-create.md
@@ -74,7 +74,7 @@ _Create Credit Memo_
 
       This field initially shows the total shipping amount from the order that is available for refund. It is equal to the full shipping amount from the order, less any shipping amount that has already been refunded. Like the quantity, the amount can be reduced, but not increased.
 
-   - For **Adjustment Refund**, enter a value to be added to the total amount refunded as an additional refund that does not apply to any particular part of the order (shipping, items, or tax).
+   - For **Adjustment Refund**, enter a value to be added to the total amount refunded as an additional refund that does not apply to any particular part of the order (shipping, items, or tax). It also can be used for partial refund with virtual money like Gift Card when an administrator wants to refund a non-virtual payment method first.
 
       The amount entered cannot raise the total refund higher than the paid amount.
 
@@ -135,7 +135,7 @@ _Create Credit Memo_
 
       This field initially displays the total shipping amount from the order that is available for refund. It is equal to the full shipping amount from the order, less any shipping amount that has already been refunded. Like the quantity, the amount can be reduced, but not increased.
 
-   - For **Adjustment Refund**, enter a value to be added to the total amount refunded as an additional refund that does not apply to any particular part of the order (shipping, items, or tax).
+   - For **Adjustment Refund**, enter a value to be added to the total amount refunded as an additional refund that does not apply to any particular part of the order (shipping, items, or tax). It also can be used for partial refund with virtual money like Gift Card when an administrator wants to refund a non-virtual payment method first.
 
       The amount entered cannot raise the total refund higher than the paid amount.
 


### PR DESCRIPTION
Update documentation about Adjustment Refund option on Credit Memo page

## Purpose of this pull request

After MC-33829 was resolved we need to update documentation about the Adjustment Refund option on the Credit Memo page. Product Owner approval for this change could be found here MC-36350.

## Magento release version

- [x] 2.4.x
- [x] 2.3.6

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

## Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/sales/credit-memo-create.html

## Links to Magento source code or PRs

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository or a code PR, add it here. -->

- https://github.com/magento/magento2ee/pull/2372
