### PR TITLE
GH661, Fix incorrect file name

### DIFF
--- a/src/marketing/google-tag-manager.md
+++ b/src/marketing/google-tag-manager.md
@@ -58,7 +58,7 @@ The following instructions show how to configure a new container with the basic 
 {:.bs-callout-info}
 For additional information, see Google's [Container export and import][5]. These instructions walk-through importing a sample JSON to a new container.
 
-1. Download the linked file [GMT_M2_Config_json.txt][6]. Then, do the following:
+1. Download the linked file [GTM_M2_Config_json.txt][6] and do the following:
 
     - Open the file in an editor, and save as `GMT_M2_Config.json`.
 

--- a/src/marketing/google-tag-manager.md
+++ b/src/marketing/google-tag-manager.md
@@ -60,9 +60,9 @@ For additional information, see Google's [Container export and import][5]. These
 
 1. Download the linked file [GTM_M2_Config_json.txt][6] and do the following:
 
-    - Open the file in an editor, and save as `GMT_M2_Config.json`.
+    - Open the file in an editor, and save as `GTM_M2_Config.json`.
 
-    - Zip the file to produce an archive called `GMT_M2_Config.zip`.
+    - Zip the file to produce an archive called `GTM_M2_Config.zip`.
 
         The zipped file will be uploaded directly to Google Tag Manager, and does not need to be copied to your server.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the file name part of #661 

The "Page not found" was due to the m2/downloads directory being removed during our changeover and removal of 2.2 docs. All of these download files are now restored, but will soon be relocated to downloads/m2 in keeping will our newer URL patterning.

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [x] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/marketing/google-tag-manager.html

