### PR TITLE
Whats new update

### DIFF
--- a/src/_data/home-sections.yml
+++ b/src/_data/home-sections.yml
@@ -2,6 +2,10 @@
     content: Discover resources available to members of the Magento ecosystem. Follow the customer journey to explore your store, and learn about key features.
     url: /getting-started.html
 
+  - title: What's new in the guide?
+    content: If you are returning to our user guide, check out our list of new topics and information updates.
+    url: /whats-new.html
+
   - title: Set up your store
     content: Manage the configuration, store information, and branding of your store. Learn digital commerce best practices.
     url: /configuration/configuration-basic.html
@@ -10,7 +14,7 @@
     content: Create products, upload images, establish pricing, and set up inventory. Organize products by category, and create a main menu for your store.
     url: /catalog.html
 
-  - title: Design and publish your pages
+  - title: Design and publish
     content: Make your site a destination with compelling content. Learn how to create pages with images, video, and dynamic content, and to modify existing pages, blocks, and widgets.
     url: /content.html
 
@@ -25,10 +29,6 @@
   - title: Manage your store
     content: Create new store views in different languages, and manage multisite installations with different currency rates and taxes. Learn to use system tools to manage store data.
     url: /stores/stores.html
-
-  - title: Manage the system
-    content: Learn how to import and export data. manage security and permissions, and install extensions. Use the system tools to manage the cache and indexing, and schedule backups.
-    url: /system/system.html
 
   - title: Share your knowledge
     content: Become a Magento documentation contributor by suggesting improvements, logging issues, and submitting revisions to our open source documentation repository.

--- a/src/_data/whats-new.yml
+++ b/src/_data/whats-new.yml
@@ -1,11 +1,46 @@
 title: What’s New in the User Guide
 description: 
   This page contains recent changes that we think you'd like to know about.
-  We exclude from this list proofreading, spelling checks, and all minor updates.
+  We exclude from this list proofreading, spelling checks, and insignificant updates.
 link: /getting-started/whats-new.html
 thread: /whatsnew-feed.xml
-updated: Tue Jul 21 11:09:27 2020
+updated: Wed Aug 26 12:49:06 2020
 entries:
+- description: Added missing options in the [Checkout Options](https://docs.magento.com/user-guide/sales/checkout-options.html)
+    topic and information about purchase order checkout in [Checkout](https://docs.magento.com/user-guide/sales/checkout-process.html).
+  versions: 2.4.x
+  type: Major update
+  date: August 25, 2020
+  link: https://github.com/magento/merchdocs/pull/682
+- description: Updated [Contact Us](https://docs.magento.com/user-guide/stores/contact-us.html)
+    to remove old information about creating a new page using HTML.
+  versions: 2.4.0
+  type: Major update
+  date: August 18, 2020
+  link: https://github.com/magento/merchdocs/pull/676
+- description: Added a new topic for updating [Multiple URL Rewrites](https://docs.magento.com/user-guide/marketing/url-rewrite-update-all.html).
+  versions: 2.4.x
+  type: New topic
+  date: August 18, 2020
+  link: https://github.com/magento/merchdocs/pull/673
+- description: Updated [Adding Product Video](https://docs.magento.com/user-guide/catalog/product-video.html)
+    to correct and clarify steps for collecting the key from the Google cloud console.
+  versions: 2.4.x
+  type: Major update
+  date: August 17, 2020
+  link: https://github.com/magento/merchdocs/pull/667
+- description: Important notation added to [In-store Delivery](https://docs.magento.com/user-guide/shipping/shipping-in-store-delivery.html)
+    about requirements before proceeding with setup.
+  versions: 2.4.0
+  type: Minor update
+  date: August 7, 2020
+  link: https://github.com/magento/merchdocs/pull/657
+- description: Information for _Password Reset Protection Type_ corrected in [Password
+    Options](https://docs.magento.com/user-guide/customers/password-options.html).
+  versions: 2.4.x
+  type: Minor update
+  date: August 5, 2020
+  link: https://github.com/magento/merchdocs/pull/650
 - description: Added new topics and updated information for the [In-store Delivery
     method](https://docs.magento.com/user-guide/shipping/shipping-in-store-delivery.html)
     provided by Inventory Management.
@@ -43,7 +78,7 @@ entries:
     topic and the [My Purchase Orders](https://docs.magento.com/user-guide/customers/account-dashboard-my-purchase-orders.html)
     topic.
   versions: 2.4.0
-  type: Major update, New topic
+  type: New topics
   date: July 28, 2020
   link: https://github.com/magento/merchdocs/pull/558
 - description: Removed the Amazon Sales Channel 2.x/3.x section due to incompatibility


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the What's New list and the home landing page to include the What's New page as a jumping off point. 

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/
https://docs.magento.com/user-guide/whats-new.html

