### PR TITLE
MC-36944: Improve "Adjust final price to this percentage" description

### DIFF
--- a/src/marketing/price-rules-catalog-create.md
+++ b/src/marketing/price-rules-catalog-create.md
@@ -108,7 +108,7 @@ Most of the available conditions are based on existing attribute values. To appl
 
    |Apply as percentage of original|Discounts item by subtracting a percentage of the regular price. For example: Enter 10 in Discount Amount for a final price that is marked down 10% from the regular price.|
    |Apply as fixed amount|Discounts item by subtracting a fixed amount from the regular price. For example: Enter 10 in Discount Amount for a final price that is $10 less than the regular price.|
-   |Adjust final price to this percentage|Adjusts the final price by a percentage of the regular price. For example: Enter 50 in Discount Amount for a final price that is marked down 50% from the regular price.|
+   |Adjust final price to this percentage|Adjusts the final price by a percentage of the regular price. For example: Enter 25 in Discount Amount for a final price that is marked down 75% from the regular price.|
    |Adjust final price to discount value|Sets the final price to a fixed, discounted amount. For example: Enter 20 in Discount Amount for a final price of $20.00.|
 
     {:.bs-callout-info}


### PR DESCRIPTION
A minor improvement to the "Adjust final price to this percentage" action description

## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) contains a minor update to the Catalog Rule action "Adjust final price to this percentage".
Currently, we have an example which tells us to reduce the price to 50% of the product's original price, and it may not be clear to the customer whether we are talking about a 50% discount or a reduction to 50% of the price.

An example from the MC-36944

> If your product base price is $100 and you select 'Adjust final price to this percentage' option and set value = 50, you will get final price = $50. But the same result you will get if select 'Apply as a percentage of original' option.

Changing the example percentage makes it clearer and easier to understand.

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [x] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/marketing/price-rules-catalog-create.html
