### PR TITLE
Remove `n` from `Google Authenticatorn`

### DIFF
--- a/src/stores/security-two-factor-authentication-use.md
+++ b/src/stores/security-two-factor-authentication-use.md
@@ -6,7 +6,7 @@ The following instructions show how to configure two-factor authentication durin
 
 ## Google Authenticator
 
-### Step 1: Configure Google Authenticatorn
+### Step 1: Configure Google Authenticator
 
 1. Enter your account credentials and sign in to the Magento _Admin_.
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

Minor spelling correction which removes an additional `n` from `Google Authenticatorn` in `security-two-factor-authentication-use.md`.

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/stores/security-two-factor-authentication-use.html#step-1-configure-google-authenticatorn
