### PR TITLE
Fix caption formatting

### DIFF
--- a/src/stores/admin-signin.md
+++ b/src/stores/admin-signin.md
@@ -13,7 +13,7 @@ For additional security, you can determine which parts of the _Admin_ each user 
 The first time you sign in to the _Admin_, you are given the opportunity to _Allow admin usage data collection_. See [Store Admin]({% link stores/admin.md %}) for more information.
 
 ![]({% link images/images/admin-login.png %}){: .zoom}
-__Admin_ Sign In_
+_Admin Sign In_
 
 ## Step 1: Set up two-factor authentication
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the formatting issue in the image caption where the `_` character is displayed

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

- https://docs.magento.com/user-guide/stores/admin-signin.html
