### PR TITLE
Remove incorrect permissions link on magento.com account share page

### DIFF
--- a/src/magento/magento-account-share.md
+++ b/src/magento/magento-account-share.md
@@ -5,7 +5,7 @@ group: getting-started
 
 Your Magento account contains information that you can make available to trusted employees and service providers who help manage your site. As the primary account holder, you have authority to grant limited access to other Magento account holders. Shared access can be revoked, but cannot be transferred from one user to another.
 
-The Magento Support team does not have access to the account and cannot set up shared access for you. Only the primary account holder with appropriate [permissions]({% link system/permissions.md %}) can set up shared access. When your account is shared, all sensitive information &#8212; such as your billing history or credit card information &#8212; remains protected and is not shared at any time with other users.
+The Magento Support team does not have access to the account and cannot set up shared access for you. Only the primary account holder with appropriate permissions can set up shared access. When your account is shared, all sensitive information &#8212; such as your billing history or credit card information &#8212; remains protected and is not shared at any time with other users.
 
 {:.bs-callout-info}
 All actions taken by users with shared access are the sole responsibility of the primary account holder. Adobe is not responsible for any actions taken by users who have shared access to your account.


### PR DESCRIPTION
## Purpose of this pull request

Remove incorrect permissions link on magento.com account share page. It was linked to [Magento Commerce permissions doc](https://docs.magento.com/user-guide/magento/magento-account-share.html), which is unrelated.

## Magento release version

n/a

## Product editions

n/a

Is this update specific to an installed feature extension

n/a

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

https://docs.magento.com/user-guide/magento/magento-account-share.html

## Additional information

Should be fixed on https://github.com/magento/merchdocs/blob/2.3-production/src/magento/magento-account-share.md too
