### PR TITLE
Added caveat for cart price rules

### DIFF
--- a/src/marketing/price-rule-cart-scheduled-changes.md
+++ b/src/marketing/price-rule-cart-scheduled-changes.md
@@ -5,8 +5,10 @@ title: Scheduled Changes for Cart Price Rules
 
 Cart price rules can be applied on schedule as part of a campaign, and grouped with other content changes. You can create a new campaign based on scheduled changes to a price rule, or apply the changes to an existing campaign.
 
-{:.bs-callout-info}
-If a campaign that includes a price rule is initially created without an end date, the campaign cannot later be edited to include an end date. It is recommended that you either add an end date when you create the campaign, or create a duplicate version of the existing campaign and add the end date to the duplicate as needed.
+Keep in mind the following caveats:
+
+- If a campaign that includes a price rule is initially created without an end date, the campaign cannot later be edited to include an end date. It is recommended that you either add an end date when you create the campaign, or create a duplicate version of the existing campaign and add the end date to the duplicate as needed.
+- When using a scheduled update to enable a cart price rule with an end date, be sure to set the rule as initially disabled. Rules that are already active will not respect the end date.
 
 If there are multiple price rules running in the same campaign, the Priority setting of the price rule determines which rule takes precedence. To learn more, see [Content Staging]({% link cms/content-staging.md -%}).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) clarifies a scenario where a cart price rule will not disable after a scheduled end date.

Fixes #842

## Product editions

- Magento Commerce only

## Affected documentation pages

- https://docs.magento.com/user-guide/marketing/price-rule-cart-scheduled-changes.html