### PR TITLE
Change "Store View" to "Website" to reflect correct Klarna configuration

### DIFF
--- a/src/payment/klarna-setup.md
+++ b/src/payment/klarna-setup.md
@@ -48,7 +48,7 @@ _Klarna Merchant Portal_
 
 1. On the Admin sidebar, go to **Stores** > _Settings_ > **Configuration**.
 
-1. In the upper-left corner, choose the **Store View** where the configuration applies. If your installation has only one view, accept the `Default Config` setting.
+1. In the upper-left corner, choose the **Website** where the configuration applies. If your installation has only one website, accept the `Default Config` setting. **NOTE: Klarna does not support configuration at the "Store View" level due to only working with base currency which is only configurable at the Website level**
 
 1. In the left panel, go to **Sales** > **Payment Methods**. Then in the **Klarna** section, click <span class="btn">Configure</span>.
 


### PR DESCRIPTION
The current docs incorrectly instruct merchants to configure Klarna at the Store View level. This is not possible. I have also added a note about not supporting configuration at the Store View level and a brief reasoning behind this.

