### PR TITLE
Adding missing info in Tax Rules doc

### DIFF
--- a/src/tax/tax-rules.md
+++ b/src/tax/tax-rules.md
@@ -33,6 +33,8 @@ _Tax Rules_
 
 ### Method 1: Enter tax rates manually
 
+1. On the _Admin_ sidebar, go to **Stores** > _Taxes_ > **Tax Zones and Rates**.
+
 1. Click <span class="btn">Add New Tax Rate</span>.
 
 1. Complete the form as needed (see [Tax Zones and Rates]({% link tax/tax-zones-rates.md %})).
@@ -43,6 +45,10 @@ _Tax Rules_
    _New Tax Rate_
 
 ### Method 2: Import tax rates
+
+1. On the _Admin_ sidebar, go to **Stores** > _Taxes_ > **Tax Rules**.
+
+1. In the upper-right corner, click <span class="btn">Add New Tax Rule</span> or open existing one from the list.
 
 1. Scroll down to the section at the bottom of the page.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) describes adding missing info in Tax Rules doc

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [x] Other feature set, please specify: Tax Rules

## Affected documentation pages

https://docs.magento.com/user-guide/tax/tax-rules.html
