### PR TITLE
Adding new pages inside Stores Menu doc

### DIFF
--- a/src/_data/toc/operations.yml
+++ b/src/_data/toc/operations.yml
@@ -32,6 +32,27 @@ pages:
         url: "/stores/store-urls-custom-admin.html"
   - label: Configuration
     url: "/stores/configuration-overview.html"
+
+  - label: Inventory
+      url: "/stores/inventory.html" !!!
+      children:
+        - label: Managing Sources !!!!
+          url: "/stores/inventory-manage-sources.html"
+            children:
+              - label: Adding a New Source
+                url: "/stores/inventory-add-new-source.html"
+        - label: Disabling Sources
+          url: "/stores/inventory-disabling-sources.html"
+        - label: Managing Stocks !!!!
+          url: "/stores/inventory-manage-stocks.html"
+            children:
+              - label: Adding a New Stock
+                url: "/stores/inventory-add-new-stock.html"
+              - label: Prioritizing Sources for a Stock
+                url: "/stores/inventory-prioritizing-sources-for-a-stock.html"
+        - label: Deleting Stocks
+            url: "/stores/inventory-deleting-stocks.html"
+
   - label: Taxes
     url: "/tax/taxes.html"
     children:

--- a/src/_data/toc/operations.yml
+++ b/src/_data/toc/operations.yml
@@ -32,27 +32,25 @@ pages:
         url: "/stores/store-urls-custom-admin.html"
   - label: Configuration
     url: "/stores/configuration-overview.html"
-
   - label: Inventory
-      url: "/stores/inventory.html" !!!
+    url: "/stores/inventory.html"
+    children:
+    - label: Managing Sources
+      url: "/stores/inventory-manage-sources.html"
       children:
-        - label: Managing Sources !!!!
-          url: "/stores/inventory-manage-sources.html"
-            children:
-              - label: Adding a New Source
-                url: "/stores/inventory-add-new-source.html"
-        - label: Disabling Sources
-          url: "/stores/inventory-disabling-sources.html"
-        - label: Managing Stocks !!!!
-          url: "/stores/inventory-manage-stocks.html"
-            children:
-              - label: Adding a New Stock
-                url: "/stores/inventory-add-new-stock.html"
-              - label: Prioritizing Sources for a Stock
-                url: "/stores/inventory-prioritizing-sources-for-a-stock.html"
-        - label: Deleting Stocks
-            url: "/stores/inventory-deleting-stocks.html"
-
+      - label: Adding a New Source
+        url: "/stores/inventory-add-new-source.html"
+      - label: Disabling Sources
+        url: "/stores/inventory-disabling-sources.html"
+    - label: Managing Stocks
+      url: "/stores/inventory-manage-stocks.html"
+      children:
+      - label: Adding a New Stock
+        url: "/stores/inventory-add-new-stock.html"
+      - label: Prioritizing Sources for a Stock
+        url: "/stores/inventory-prioritizing-sources-for-a-stock.html"
+      - label: Deleting Stocks
+        url: "/stores/inventory-deleting-stocks.html"
   - label: Taxes
     url: "/tax/taxes.html"
     children:

--- a/src/stores/inventory-add-new-source.md
+++ b/src/stores/inventory-add-new-source.md
@@ -1,0 +1,121 @@
+---
+title: Adding a New Source
+---
+
+Manage inventory and order fulfillment from multiple locations with custom sources. Create a source for each location such as warehouses, brick-and-mortar stores, distribution centers, and drop shippers. Assign sources and update quantities per product
+
+If editing the Default Source, you can edit all configurations except name and code. We recommend single source merchants add information matching their location.
+
+## Add a new inventory source
+
+1. On the _Admin_ sidebar, go to **Stores** > _Inventory_ > **Sources**.
+
+1. Click <span class="btn">Add New Source</span>.
+
+   ![]({% link images/images/stores-inventory-sources.png %}){: .zoom}
+   _Manage Sources_
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the **General** section and do the following:
+
+    - Enter a unique **Name** to identify the inventory source.
+
+    - Enter a unique **Code**.
+
+      The code supports upper and lower case letters, numbers, dashes, and underscores. The code is a unique ID used when assigning to stock and exporting-importing data.
+
+    - If this inventory source is ready to use, set **Is Enabled** to `Yes`.
+
+    - Enter a brief **Description** for this location for quick reference or additional details.
+
+    - For **Latitude** and **Longitude**, enter the Global Positioning System (GPS) coordinates of the facility location.
+
+      To find the GPS coordinates with [Google Maps][1], enter the address in the **Search** box. Right-click the marker on the map and choose **What’s here?**. The GPS coordinates appear in the details box below the street address.
+
+      ![]({% link images/images/stores-inventory-source-general.png %}){: .zoom}
+      _General_
+
+    - If this inventory source is a pickup location, set **Use as Pickup Location** to `Yes`.
+
+      The Default Source cannot be used as a pickup location for in-store pickup orders.
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the **Contact Info** section and do the following:
+
+    - For **Contact Name**, enter the full name of the primary contact at the location.
+
+    - Enter an **Email** address for contacting the location.
+
+    - For **Phone**, enter the area code and phone number.
+
+    - For **Fax**, enter the area code and phone number of the fax, if available.
+
+      ![]({% link images/images/stores-inventory-source-contact-info.png %}){: .zoom}
+      _Contact Info_
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the **Address Data** section and do the following:
+
+    - Choose the **Country**.
+
+    - For **State/Province**, enter the standard abbreviation for the state or province.
+
+    - Enter the **City**.
+
+    - Enter the physical **Street** address.
+
+    - For **Postcode**, enter the ZIP or postal code.
+
+      ![]({% link images/images/stores-inventory-source-address-data.png %}){: .zoom}
+      _Address Data_
+
+1. If you set the source as a pickup location in the earlier step, expand ![]({% link images/images/btn-expand.png %}) the **Pickup Location** section and provide descriptive information about the location:
+
+    - Enter the **Frontend Name** of the pickup location.
+
+    - Enter a **Frontend Description** of the pickup location. Use this text box to display store hours, the location relative to other landmarks, or other useful information that will help the customer select the correct pickup location.
+
+      ![]({% link images/images/stores-inventory-pickup-location.png %}){: .zoom}
+      _Pickup Location_
+
+    For more information about how to configure email notifications when using a source as a pickup location, see [Sales Emails]({% link configuration/sales/sales-emails.md %}).
+
+1. To save your work, do one of the following:
+
+    - To save your work and continue editing, click <span class="btn">Save & Continue</span>.
+
+    - To save your work and return to the Manage Sources page, click the down arrow ( ![]({% link images/images/btn-dropdown.png %})) and choose **Save & Close**.
+
+    - To save your work on the current source record and enter a new source, choose **Save & New**.
+
+## Button bar
+
+|Button|Description|
+|--|--|
+|Back|Returns to the Manage Sources page.|
+|Reset|Restores all fields in the form to their values at the time of the last save.|
+|Save & Continue|Saves all changes and keeps the form open for further editing. Click the down arrow for additional options:<br/>**Save & Close** - Saves changes to the current record, closes the form, and returns to the Manage Sources page.<br/>**Save & New** - Saves changes, closes the current record, and opens a new blank form.|
+
+## Field descriptions
+
+|Field|Description|
+|--|--|
+|**General**| |
+|Name|(Required) A unique name that identifies the  inventory source for Admin users.|
+|Code|(Required) A unique, alphanumeric code that is used by the system to identify the inventory source. Enter the code in upper or lowercase characters and/or numbers, without spaces. If necessary, a hyphen or underscore can be used instead of a space. The code cannot be edited after creating the source. It is a unique ID used when you assign sources to stocks and export and/or import product data.|
+|Is Enabled|Determines if the inventory source is available to be used. Options: Yes / No|
+|Description|A brief description of the inventory source location. Include details helpful to your Admin users.|
+|Latitude|Specifies the latitude coordinate of the inventory source for GPS. Enter the value  as a number, preceded by a plus or minus sign as needed. The degree symbol and letters are not permitted. For example: Latitude 32.7555|
+|Longitude|Specifies the longitude coordinate of the inventory source for GPS. Enter the value  as a number, preceded by a plus or minus sign as needed. The degree symbol and letters are not permitted. For example: Longitude -97.3308|
+|**Contact Info**| |
+|Contact Name|The name of the primary contact at the inventory source location.|
+|Email|The email of the primary contact.|
+|Phone|The area code and telephone number of the primary contact, using the format that you prefer.  For example: (123) 456-7890 or 123-456-7890|
+|Fax|The area code and fax number of the primary contact.|
+|**Address Data**| |
+|Country|(Required) The country where the inventory source is located.|
+|State/Province|The state or province where the inventory source is located.|
+|City|The city where the inventory source is located.|
+|Street|The street address of the inventory source.|
+|Postcode|(Required) The ZIP or postal code of the inventory source.|
+|**Pickup Location**| |
+|Frontend Name|The name of the pickup location for the source.|
+|Frontend Description|The description of the pickup location for the source. It can contain attached images.|
+

--- a/src/stores/inventory-add-new-stock.md
+++ b/src/stores/inventory-add-new-stock.md
@@ -1,0 +1,70 @@
+---
+title: Adding a New Stock
+---
+
+Stocks map your sources to sales channels (or websites), providing a direct link to salable quantities and product inventories.
+
+When creating a custom stock, you assign websites and sources. Sources can include enabled and disabled sources. For example, you may add a new warehouse to your stock, preparing to open the location for managing inventory and completing shipments.
+
+After adding sources, you need to prioritize the order for the sources from top (first) to bottom (last). This order affects recommendations during order shipment.
+
+![]({% link images/images/stores-inventory-stock-new.png %}){: .zoom}
+_New Stock_
+
+## Add new stock
+
+1. On the _Admin_ sidebar, go to **Stores** > _Inventory_ > **Stock**.
+
+1. Click <span class="btn">Add New Stock</span>.
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the **General** section and enter a unique **Name** to identify the new stock.
+
+   ![]({% link images/images/stores-inventory-stock-general.png %}){: .zoom}
+   _General_
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the **Sales Channels** section and select the **Websites** where this stock is available.
+
+   For a multisite installation, hold down the Ctrl key (PC) or the Command key (Mac) and click each website.
+
+   {:.bs-callout-info}
+   If you select a website or sales channel assigned to another stock, it will be unassigned from that stock. Any Sales Channels not assigned to a custom stock are assigned to the Default Stock.
+
+   ![]({% link images/images/stores-inventory-stock-sales-channel.png %}){: .zoom}
+   _Sales Channels_
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the **Sources** section and do the following for any stock other than the default:
+
+    - Click <span class="btn">Assign Sources</span>.
+
+    ![]({% link images/images/stores-inventory-stock-sources.png %}){: .zoom}
+    _Assigned Sources_
+
+    - Select checkboxes for all sources you want to assign to the stock.
+
+    - Click <span class="btn">Done</span>.
+
+      The added sources display in Assigned Sources.
+
+      ![]({% link images/images/stores-inventory-stock-assign-sources.png %}){: .zoom}
+      _Assign Sources to Stock_
+
+1. Use ![]({% link images/images/btn-sort-3.png %}) to drag and drop the sources into a priority from top (first) to bottom (last).
+
+   This order is important when shipping orders.
+
+   ![]({% link images/images/stores-inventory-stock-priorityafter.png %}){: .zoom}
+   _Assigned Sources Example_
+
+1. On the **Save** (![]({% link images/images/btn-dropdown.png %})) menu, choose **Save & Close**.
+
+## Field descriptions
+
+|Field|Description|
+|--|--|
+|**General**| |
+|Name|Name for the stock. For example: UK Stock, US Stock|
+|**Sales Channels**| |
+|Websites|Defines the [scope]({% link configuration/scope.md %}) of the stock by assigning the stock to specific website(s) as _sales channels_. Select one or more websites per stock. Each website can only be assigned to one stock.|
+|**Sources**| |
+|Assign Sources|Assigns inventory sources to this stock. Custom sources cannot be assigned to Default Stock.|
+|Assigned Sources|List of assigned sources. Drag and drop the sources using ![]({% link images/images/btn-sort-3.png %}) into a prioritized order for order fulfillment and shipping.<br/><br/>**Code** - Unique code ID for the source.<br/>**Name** - Name description for the source.<br/>**Unassign** - Remove the assigned source from the stock using ![]({% link images/images/btn-trashcan2.png %}).|

--- a/src/stores/inventory-deleting-stocks.md
+++ b/src/stores/inventory-deleting-stocks.md
@@ -1,0 +1,26 @@
+---
+title: Deleting Stocks
+---
+
+When you delete the stock, all assigned web sites are assigned to the Default Stock. We recommend reassigning websites to other stocks prior to deletion.
+
+{:.bs-callout-info}
+**Important:** Deleting a [stock]({% link catalog/inventory-stock.md %}) can affect salable quantities and unprocessed orders for a sales channel. If you continue using a sales channel, please add the sales channel to another existing or new stock.
+
+1. On the _Admin_ sidebar, go to **Stores** > _Inventory_ > **Stocks**.
+
+1. Select one or more stocks to delete.
+
+   Browse or search and select checkboxes for stocks you want to delete.
+
+1. From the **Actions** menu, select **Delete**.
+
+    ![]({% link images/images/inventory/inventory-stock-delete1.png %}){: .zoom}
+    _Select Delete from the Actions menu_
+
+1. In the confirmation dialog, click <span class="btn">OK</span>.
+
+   The stock is deleted and any assigned sales channels are unmapped.
+
+    ![]({% link images/images/inventory/inventory-stock-delete2.png %}){: .zoom}
+    _Stock delete verification message_

--- a/src/stores/inventory-disabling-sources.md
+++ b/src/stores/inventory-disabling-sources.md
@@ -1,0 +1,47 @@
+---
+title: Disabling Sources
+---
+
+Sources may not be deleted to ensure all order data retains in Magento. Sources, orders, and shipments are directly connected to each other. You can disable sources and modify information including location and point of contact.
+
+Depending on the status of your locations, you may need to disable a source. A disabled source retains all assignments per stocks and products but is not accessed for inventory and orders.
+
+When a source is disabled:
+
+- Inventory Management ignores and does not list the source for shipment or order processing.
+- Stocks do not access inventory quantities from the source for aggregated inventory totals.
+- Order shipments cannot be assigned to disabled locations.
+
+You cannot disable the Default Source. Magento uses this source for all new, imported products, for bundle products, and for third-party system support. You can enable or disable custom sources at any time.
+
+Setting a source to `disabled` is helpful for the following situations:
+
+- Adding a new store or warehouse - As you open new storefronts or bring new warehouses and shipment locations online, add a source entry to set up product inventory using import and connect to potential stocks.
+- Seasonal shipments - Holidays can be an extremely busy time of the year. You may want to restrict shipping only from specific shipment locations such as warehouses to keep brick-and-mortar locations well stocked and focused on local shoppers. Or you may add new shipment locations for a limited time to handle higher rates of sales and incoming orders.
+- Closing a location - When closing a location for movement to new facilities or permanently, disable to stop new shipments from the location.
+
+## Disable one or more custom sources
+
+1. On the _Admin_ sidebar, go to **Stores** > _Inventory_ > **Sources**.
+
+1. Select the checkbox for each enabled custom source that you want to disable.
+
+1. Click the _Actions_ menu at the upper-left corner and choose **Disable**.
+
+   ![Inventory Management sources - Actions menu]({% link images/images/stores-inventory-sources-disable.png %}){: .zoom}
+   _Actions menu_
+
+1. In the confirmation dialog, click <span class="btn">OK</span>.
+
+## Enable or disable a single custom source
+
+1. On the _Admin_ sidebar, go to **Stores** > _Inventory_ > **Sources**.
+
+1. Locate a custom source and click **Edit**.
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the _General_ section and change **Is Enabled**:
+
+    | Yes | Source is enabled. The quantity adds to Salable Quantity. The source lists with current quantity when shipping orders. The Source Selection Algorithm checks it the source for shipping. |
+    | No | Source is disabled. Quantities are not added to Salable Quantities. The source does not list when shipping orders. Shipping options skip this source. |
+
+1. Click <span class="btn">Save and Close</span>.

--- a/src/stores/inventory-manage-sources.md
+++ b/src/stores/inventory-manage-sources.md
@@ -1,0 +1,58 @@
+---
+title: Managing Sources
+---
+
+Sources are the physical locations where product inventory is managed and shipped for order fulfillment, or where services are available. These locations can include warehouses, brick-and-mortar stores, distribution centers, pickup locations, and drop shippers. You allocate inventory quantities to these sources, and Magento automatically aggregates the total salable products for your stocks. For large companies, add multiple sources for all of your locations: in different geographic locations by country and continent, locations in a city, based on the type of inventory, even based on services.
+
+It is recommended to provide specific physical geographical locations when creating a source. That allows the _Distance Priority Algorithm_ to compare the location of the shipping destination address with the available source locations to determine the closest source to fulfill shipments. You can use Google Maps or offline calculations, which use geocodes. For more information on this _Distance Priority Algorithm_, see [Configure Distance Priority Algorithm]({% link catalog/inventory-configure-distance-priority.md %}).
+
+You start with a Default Source you can update but not disable. This source is used by Single Source Merchants and for product migration. You always need a default source.
+
+- **Location Information** - Each source includes the name, country, physical address of the location, and a point of contact. Future releases for MSI will include additional types and information for sources.
+- **Enabling Resources** - You can enable and disable sources as needed. Only enable a source if it accepts and fulfills orders and backorders.
+- **Available Inventory** - Assign and update inventory quantities for each source through the product page. The inventory quantities are calculated, provided, and reserved through the source and stock mapping.
+
+The following diagram helps define the Sources for a Bicycle Shop merchant selling a mountain bike, available to stocks and accessible by the SSA for shipments.
+
+![Example sources diagram]({% link images/images/inventory/inventory-diagram-sources.png %})<br/>
+_Example Sources for a Mountain Bike_
+
+All stores begin with a Default Source that must remain enabled:
+
+- All new products imported into Magento require a source and stock, automatically assigned for immediate access to inventory management.
+- Single Source merchants use the Default Source as their single point of inventory location and shipments.
+
+## Edit sources
+
+You can update the name, address, GPS location, and point of contact information. The source's code is a protected value, acting as a unique ID associating the source with your product quantities and stocks.
+
+If editing the Default Source, you can edit all configurations except the name and code. We recommend Single Source merchants add information matching their location.
+
+The Manage Sources page lists all available inventory locations and fulfillment facilities. You can add new inventory sources, and edit existing locations.
+
+1. On the _Admin_ sidebar, go to **Stores** > _Inventory_ > **Sources**.
+
+1. To add a new inventory location, see [Adding a New Source]({% link catalog/inventory-sources-add.md %}).
+
+1. Find the inventory source and open it in **Edit** mode.
+
+1. Update the information and save the changes.
+
+   ![Manage Sources]({% link images/images/stores-inventory-sources.png %}){: .zoom}
+   _Manage Sources_
+
+## Button bar
+
+|Button|Description|
+|--|--|
+|Add New Source|Opens the New Source form that is used to enter a new inventory source, fulfillment facility, or location.|
+
+## Manage sources column descriptions
+
+|Column|Description|
+|--|--|
+|Code|A unique, alphanumeric code that is used by the system to identify the inventory source.|
+|Name|A unique name that identifies the  inventory source for Admin users.|
+|Is Enabled|Indicates if the inventory source is active and available to use.|
+|Pickup Location|Indicates if the source is active as a pickup location for [in-store delivery]({% link shipping/shipping-in-store-delivery.md %}).|
+|Action|Clicking **Edit** opens the inventory source record in edit mode.|

--- a/src/stores/inventory-manage-stocks.md
+++ b/src/stores/inventory-manage-stocks.md
@@ -1,0 +1,48 @@
+---
+title: Managing Stock
+---
+
+Stock represents a virtual, aggregated inventory of products for sources of your sales channels (currently these are websites). Depending on your site configuration, the stock may be assigned to one or more sales channels. Each sales channel can only have a single stock assigned to it, and a single stock can be assigned to multiple websites. Through the stock, you can modify the prioritization of sources used as orders come through a website.
+
+You start with a Default Stock that cannot be removed or disabled. You can add additional sales channels to the stock only. The only assigned source is Default Source. This stock is used by Single Source Merchants, 3rd party integrations, and imported products.
+
+Sales Channels represent entities selling your inventory. By default, Magento provides your store websites as sales channels. Sales channels can be extended to support additional channels such as B2B customers groups and store views. Each sales channels can only be associated to one Stock.
+
+- **Sales Channel Support** - Sales channels currently include websites out-of-the-box. You can extend sales channels to include custom options like B2B customers groups and store views. Each sales channel can only have a single stock assigned to it. A single stock can be assigned to multiple websites.
+- **Map to Sources** - Each stock can have one or more enabled or disabled sources assigned, calculating the virtual aggregated inventory per product.
+- **Priority Order Fulfillment** - The out-of-the-box Priority algorithm for the Source Selection Algorithm uses the stock's source list from top-to-bottom when fulfilling orders.
+
+The following diagram helps define how a Stock works in relation to Sources and Sales Channels for a Bicycle Shop merchant.
+
+![]({% link images/images/inventory/inventory-diagram-stock.png %})
+
+## Example stocks for a mountain bike and store
+
+All stores start with a Default Stock. It must remain "Enabled" for the following reasons:
+
+- It is used when importing new products, automatically assigning products to the default source and stock for immediate access to inventory management.
+- You cannot add additional sources beyond the Default Source to this stock.
+- It is required and used by Single Source merchants, Bundle products, and Grouped products.
+
+For Multi Source merchants, create and configure stocks as needed to best fit your stores and order fulfillment. When you assign new stock to a sales channel, any pre-existing stock in that sales channel becomes unassigned.
+
+For a multisite installation, the Default Stock is initially assigned to the [Main Website]({% link stores/stores-all-create-website.md %}) and default store.
+
+![]({% link images/images/stores-inventory-stock.png %}){: .zoom}
+_Manage Stock_
+
+## Button bar
+
+|Button|Description|
+|--|--|
+|Add New Stock|Opens the New Stock form that is used to enter a new inventory stock for mapping inventory to sales channel.|
+
+## Manage Stock column descriptions
+
+|Column|Description|
+|--|--|
+|ID|Unique, numeric ID generated for the stock entry.|
+|Name|Unique name that identifies the inventory stock.|
+|Sales Channels|Defines the [scope]({% link configuration/scope.md %}) of the stock by assigning the stock to specific website(s) as _sales channels_.|
+|Assigned sources|Sources assigned to the stock that supply all product quantities.|
+|Action|**Edit** - Opens the inventory stock record in edit mode.|

--- a/src/stores/inventory-prioritizing-sources-for-a-stock.md
+++ b/src/stores/inventory-prioritizing-sources-for-a-stock.md
@@ -1,0 +1,19 @@
+---
+title: Prioritizing Sources for a Stock
+---
+
+After adding [sources]({% link catalog/inventory-sources.md %}) to the [stock]({% link catalog/inventory-stock.md %}), arrange those sources from top-to-bottom in priority for fulfilling orders. The Source Selection Algorithm (SSA) provides an algorithm Priority using this order when determining shipment and inventory deductions.
+
+The source priority on stocks does not influence assigned sources when editing product inventories.
+
+In this example, the UK Stock has sources assigned out of order for a store and two warehouses in London and a warehouse in Berlin.
+
+![]({% link images/images/stores-inventory-stock-prioritybefore.png %}){: .zoom}
+_Source order before prioritization_
+
+The merchant prefers to have shipments prioritized from the larger Berlin warehouse, then the London warehouse, the London overflow location, and finally the storefront in London. To reorder, the entries are dragged and dropped in order.
+
+Use ![]({% link images/images/btn-sort-3.png %}){: .Inline} to drag and drop the sources into a priority from top (first) to bottom (last). This order is important when shipping orders. SSA recommends shipments based on the order of sources
+
+![]({% link images/images/stores-inventory-stock-priorityafter.png %}){: .zoom}
+_Source order after prioritization_

--- a/src/stores/inventory.md
+++ b/src/stores/inventory.md
@@ -1,0 +1,8 @@
+---
+title: Inventory
+---
+
+[Magento Inventory Management]({% link catalog/inventory-management.md %}) gives you the tools to manage your product inventory. Merchants with a single store to multiple warehouses, stores, pickup locations, drop shippers, and more can use these features to maintain quantities for sales and handle shipments to complete orders. 
+You can track your inventory quantities, provide accurate salable stock amounts to customers for all of your websites, and ship according to recommendations based on distance or priority. 
+You can also configure your preferred product configurations globally (for all stores and products), per source, and per product. 
+These features grow with your business, allowing you to work from a single warehouse or complex shipping network with a few additional settings.

--- a/src/stores/inventory.md
+++ b/src/stores/inventory.md
@@ -2,7 +2,7 @@
 title: Inventory
 ---
 
-[Magento Inventory Management]({% link catalog/inventory-management.md %}) gives you the tools to manage your product inventory. Merchants with a single store to multiple warehouses, stores, pickup locations, drop shippers, and more can use these features to maintain quantities for sales and handle shipments to complete orders. 
-You can track your inventory quantities, provide accurate salable stock amounts to customers for all of your websites, and ship according to recommendations based on distance or priority. 
-You can also configure your preferred product configurations globally (for all stores and products), per source, and per product. 
+[Magento Inventory Management]({% link catalog/inventory-management.md %}) gives you the tools to manage your product inventory. Merchants with a single store to multiple warehouses, stores, pickup locations, drop shippers, and more can use these features to maintain quantities for sales and handle shipments to complete orders.
+You can track your inventory quantities, provide accurate salable stock amounts to customers for all of your websites, and ship according to recommendations based on distance or priority.
+You can also configure your preferred product configurations globally (for all stores and products), per source, and per product.
 These features grow with your business, allowing you to work from a single warehouse or complex shipping network with a few additional settings.

--- a/src/stores/stores.md
+++ b/src/stores/stores.md
@@ -9,6 +9,10 @@ sections:
    content: Our online Configuration Reference has field descriptions for every setting.
    url: /stores/configuration.html
 
+ - title: Inventory
+   content: Learn how to create and manage stocks to link your sales channels or websites to sources.
+   url: /stores/inventory.html
+
  - title: Taxes
    content: Learn how to set up tax classes for products and customer groups, and manage tax zones and rates according to the requirements of your locale.
    url: /tax/taxes.html


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) describes adding new pages (about Inventory functionality) inside Stores Menu doc

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [x] Other feature set, please specify: Stores Menu

## Affected documentation pages
https://docs.magento.com/user-guide/stores/stores.html

## Links to Magento source code or PRs

https://docs.magento.com/user-guide/catalog/inventory-management.html

