### PR TITLE
2.3 deprecate Braintree

### DIFF
--- a/src/payment/braintree.md
+++ b/src/payment/braintree.md
@@ -5,7 +5,7 @@ title: Braintree
 {:.bs-callout-warning}
 **Deprecation Notice** <br/>
 Due to the Payment Service Directive [PSD2]({% link stores/compliance-payment-services-directive.md %}) and the continued evolution of many APIs, this payment integration is at risk of becoming outdated and no longer security compliant. For this reason, it is now deprecated and we are recommending that you disable it in your Magento 2.3.x configuration and transition to the official Braintree payment extension from [Magento Marketplace](https://marketplace.magento.com/catalogsearch/result/?q=braintree). <br/><br/>
-**This integration has been deprecated from current versions of 2.3.x.**<br/><br/>
+**This integration has been deprecated from current versions of 2.3.x. and replaced with a different Braintree integration in 2.4.0 and later.**<br/><br/>
 
 Braintree offers a fully customizable checkout experience with fraud detection and PayPal integration. Braintree reduces the PCI compliance burden for merchants because the transaction takes place on the Braintree system.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) allows us to merge change from #860 into 2.3 production due to the CLA issue. Contributor is an Adobe employee.

## Magento release version

- [ ] 2.4.x

   Specify a patch release number, if applicable:

- [x] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/v2.3/payment/braintree.html