### PR TITLE
Fixing links to old catalog filtering content

### DIFF
--- a/src/marketing/prex-type-mostaddcart.md
+++ b/src/marketing/prex-type-mostaddcart.md
@@ -7,7 +7,7 @@ The _Most added to cart_ recommendation type recommends items most added to a ca
 
 ## How it works
 
-Belonging to a category of recommendation types that are popularity-based, _Most added to cart_ recommends products that were more frequently added to a cart by counting the number of sessions where an add-to-cart action occurred within the last seven days. You can use this recommendation type on all page types. This recommendation type uses [catalog filtering]({% link marketing/product-recommendations.md %}#filter-recommendations) to determine which products to display.
+Belonging to a category of recommendation types that are popularity-based, _Most added to cart_ recommends products that were more frequently added to a cart by counting the number of sessions where an add-to-cart action occurred within the last seven days. You can use this recommendation type on all page types.
 
 ### Where used
 

--- a/src/marketing/prex-type-mostpurchase.md
+++ b/src/marketing/prex-type-mostpurchase.md
@@ -7,7 +7,7 @@ Commonly referred to as Top sellers, the _Most purchased_ recommendation type re
 
 ## How it works
 
-Belonging to a category of recommendation types that are popularity-based, _Most purchased_ recommends products by counting the number of sessions where a place-order action occurred within the last seven days. You can use this recommendation type on all page types. This recommendation type uses [catalog filtering]({% link marketing/product-recommendations.md %}#filter-recommendations) to determine which products to display.
+Belonging to a category of recommendation types that are popularity-based, _Most purchased_ recommends products by counting the number of sessions where a place-order action occurred within the last seven days. You can use this recommendation type on all page types.
 
 ### Where used
 

--- a/src/marketing/prex-type-mostviewed.md
+++ b/src/marketing/prex-type-mostviewed.md
@@ -7,7 +7,7 @@ The _Most viewed_ recommendation type recommends items most viewed within the la
 
 ## How it works
 
-Belonging to a category of recommendation types that are popularity-based, _Most viewed_ recommends products that were the most viewed by counting the number of sessions where a view action occurred within the last seven days. You can use this recommendation type on all page types. This recommendation type uses [catalog filtering]({% link marketing/product-recommendations.md %}#filter-recommendations) to determine which products to display.
+Belonging to a category of recommendation types that are popularity-based, _Most viewed_ recommends products that were the most viewed by counting the number of sessions where a view action occurred within the last seven days. You can use this recommendation type on all page types.
 
 ### Where used
 

--- a/src/marketing/product-recommendations.md
+++ b/src/marketing/product-recommendations.md
@@ -39,20 +39,6 @@ The following recommendation types will fallback to **Most viewed** if there is 
 
 - **Trending**
 
-## Filter recommendations {#filter-recommendations}
-
-Magento defines default filters for the **Most popular**, **Trending**, and **Recommended for you** recommendation types. By filtering recommendations, Magento provides more relevant results. For example, if you deploy the **Most popular** recommendation type to a product detail page, you would not want products from the entire catalog to be displayed, but rather a smaller subset of products relevant to the product being viewed.
-
-The following table describes how the **Most popular**, **Trending**, and **Recommended for you** recommendation types are filtered based on the page.
-
-|Page|Filtered By|
-|---|---|
-|Home|No filter|
-|Category|Products under that category|
-|Product Detail|Products under that product's category(-ies)|
-|Cart|Categories of the products in the shopper's cart|
-|Order Confirmation|Categories for products the shopper just purchased|
-
 ## Product recommendations placement {#productrecplacement}
 
 You can place the recommendations in one of the following page locations.

--- a/src/marketing/recommendation-incl-excl.md
+++ b/src/marketing/recommendation-incl-excl.md
@@ -26,11 +26,11 @@ Magento provides the following inclusion and exclusion filters you can use to co
 
 When creating filters for categories, Magento recommends the following best practices:
 
-|Page|Filter By|
+|Page|Filter by|
 |---|---|
 |Home|No filter|
 |Category|Products under that category|
-|Product Detail|Products under that product's category(-ies)|
+|Product Detail|Products under that product's categories|
 |Cart|Categories of the products in the shopper's cart|
 |Order Confirmation|Categories for products the shopper just purchased|
 

--- a/src/marketing/recommendation-incl-excl.md
+++ b/src/marketing/recommendation-incl-excl.md
@@ -24,6 +24,16 @@ Magento provides the following inclusion and exclusion filters you can use to co
 - **Type** - Filters based on product type, such as: _Simple_, _Configurable_, _Virtual_, _Downloadable_, or _Gift card_.  _Bundled_ and _Grouped_ products are [not yet supported]({% link marketing/product-recs-limitations.md %}).
 - **Visibility** - Filters products based on visibility, such as: _Catalog_, _Search_, or both.
 
+When creating filters for categories, Magento recommends the following best practices:
+
+|Page|Filter By|
+|---|---|
+|Home|No filter|
+|Category|Products under that category|
+|Product Detail|Products under that product's category(-ies)|
+|Cart|Categories of the products in the shopper's cart|
+|Order Confirmation|Categories for products the shopper just purchased|
+
 ### Enable and disable filters
 
 You can configure multiple filters and choose to enable only those you want by selecting the toggle on each filter page. This allows you to create drafts of filters for future use. The enabled filter count is displayed on the tabs.

--- a/src/system/catalog-sync.md
+++ b/src/system/catalog-sync.md
@@ -22,7 +22,7 @@ To access the Catalog Sync dashboard, select **System** > _Data Transfer_ > **Ca
 Reports a sync status of:
 
 - **Success** - Displays the date and time the sync was successful and the number of products updated
-- **Failure** - Displays the date and time the sync was attempted
+- **Failed** - Displays the date and time the sync was attempted
 - **In Progress** - Displays the date and time of the last successful sync
 
 {:.bs-callout-info}
@@ -58,11 +58,8 @@ Name | Storefront name of the product
 Type | Identifies the product type, such as simple, configurable, downloadable, and so on
 Last Exported | Date the product was last successfully exported from your catalog
 Last Modified | Date the product was last modified in your catalog
-Attribute Set | Specifies the [attribute set]({% link stores/attribute-sets.md %}) for this product
 SKU | Displays the stock keeping unit for the product
 Price | Price of the product
-Quantity | Identifies the on-hand, available stock amount
-Salable Quantity | Reflects the salable quantity for a stock
 Visibility | A product's visibility setting as defined in the Magento catalog
 
 ## Resolve catalog sync issues {#resolvesync}


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) fixes several links to the old catalog filtering content. Also updated based on feedback from prex devs.

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/marketing/product-recommendations.html
- https://docs.magento.com/user-guide/marketing/recommendation-incl-excl.html
- https://docs.magento.com/user-guide/marketing/prex-type-mostviewed.html
- https://docs.magento.com/user-guide/marketing/prex-type-mostaddcart.html
- https://docs.magento.com/user-guide/marketing/prex-type-mostpurchase.html
- https://docs.magento.com/user-guide/system/catalog-sync.html

