### PR TITLE
Enable MD linter in SuperLinter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,10 +19,6 @@ on:
     branches:
       - master
       - 2.*-develop
-    paths-ignore:
-      - '**.md'
-      - '**.html'
-      - '**.xml'
 
 ###############
 # Set the Job #
@@ -53,6 +49,6 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
+          MARKDOWN_CONFIG_FILE: .markdownlint.json
           VALIDATE_HTML: false
-          VALIDATE_MARKDOWN: false
           VALIDATE_XML: false


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) configures SuperLinter's workflow to enable Markdown checking. We did this before, but the linter didn't work as expected because of incorrect configuration of the workflow.

By default, the Markdown linter uses configuration from the `.markdown-lint.yml`. To enable reuse of the configuration in Visual Studio Code via a symlink locally, we use the `.markdownlint.json` filename.

Tested on the entire content, the tool even found some violations that were not previously detected by `mdl`.

Related topics:
- https://github.com/github/super-linter#environment-variables
- https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint

Related PR: magento/devdocs#8357