### PR TITLE
Fix nav and topic for downloadable products

### DIFF
--- a/src/_data/toc/operations.yml
+++ b/src/_data/toc/operations.yml
@@ -167,6 +167,8 @@ pages:
         url: "/system/data-transfer-bundle-products.html"
       - label: Configurable Products
         url: "/system/data-transfer-configurable-products.html"
+      - label: Downloadable Products
+        url: "/system/data-transfer-downloadable-products.html"
       - label: Importing Tier Prices
         url: "/system/data-import-price-tier.html"
     - label: Scheduled Import/Export

--- a/src/system/data-transfer-downloadable-products.md
+++ b/src/system/data-transfer-downloadable-products.md
@@ -2,23 +2,21 @@
 title: Importing Downloadable Products
 ---
 
-The flow of importing downloadable products is the same as for [Bundle Products]({% link system/data-transfer-bundle-products.md %}) or [Configurable Products]({% link system/data-transfer-configurable-products.md %}).
-
-The only difference is that a downloadable product has [downloadable links]({% link catalog/product-create-downloadable.md%}#complete-the-links) and [downloadable samples]({% link catalog/product-create-downloadable.md%}#complete-the-samples) along with its images.
+The flow for importing downloadable products is the same as for [Bundle Products]({% link system/data-transfer-bundle-products.md %}) or [Configurable Products]({% link system/data-transfer-configurable-products.md %}). The difference is that a downloadable product has [downloadable links]({% link catalog/product-create-downloadable.md%}#complete-the-links) and [downloadable samples]({% link catalog/product-create-downloadable.md%}#complete-the-samples) with its images.
 
 The default root directory for downloadable links and samples is `<Magento-root-folder>/pub/media/import`. If the Remote storage module is enabled, the default root directory for downloadable links and samples is the `<remote-storage-root-folder>/media/import` directory.
 
 The CSV file has separate columns for `downloadable_links` and `downloadable_samples`.
 
-In the following example, downloadable link images (`red.jpg` and `black.jpg`) are located in the `<Magento-root-folder>/pub/media/import/test` folder. If remote storage is enabled, these images are located in the `<remote-storage-root-folder>/media/import/test` folder.
+-  **Downloadable link images**—In the following example, downloadable link images (`red.jpg` and `black.jpg`) are located in the `<Magento-root-folder>/pub/media/import/test` folder. If remote storage is enabled, these images are located in the `<remote-storage-root-folder>/media/import/test` folder.
 
-![Example data - downloadable product with downloadable links]({% link images/images/data-import-downloadable-links.png %}){: .zoom}
-_Downloadable Links_
+   ![Example data - downloadable product with downloadable links]({% link images/images/data-import-downloadable-links.png %}){: .zoom}
+   _Downloadable Links_
 
-In the following example, the downloadable sample image (`white.jpg`) is located in the `<Magento-root-folder>/pub/media/import/test` folder. If remote storage is enabled, this image is located in the `<remote-storage-root-folder>/media/import/test` folder.
+-  **Downloadable sample images**—In the following example, the downloadable sample image (`white.jpg`) is located in the `<Magento-root-folder>/pub/media/import/test` folder. If remote storage is enabled, this image is located in the `<remote-storage-root-folder>/media/import/test` folder.
 
-![Example data - downloadable product with downloadable samples]({% link images/images/data-import-downloadable-samples.png %}){: .zoom}
-_Downloadable Samples_
+   ![Example data - downloadable product with downloadable samples]({% link images/images/data-import-downloadable-samples.png %}){: .zoom}
+   _Downloadable Samples_
 
 For more information about enabling and managing the Remote storage module, see [Configure remote storage][1] in the _Configuration guide_.
 

--- a/src/system/data-transfer-downloadable-products.md
+++ b/src/system/data-transfer-downloadable-products.md
@@ -8,14 +8,14 @@ The default root directory for downloadable links and samples is `<Magento-root-
 
 The CSV file has separate columns for `downloadable_links` and `downloadable_samples`.
 
--  **Downloadable link images**—In the following example, downloadable link images (`red.jpg` and `black.jpg`) are located in the `<Magento-root-folder>/pub/media/import/test` folder. If remote storage is enabled, these images are located in the `<remote-storage-root-folder>/media/import/test` folder.
+- **Downloadable link images**—In the following example, downloadable link images (`red.jpg` and `black.jpg`) are located in the `<Magento-root-folder>/pub/media/import/test` folder. If remote storage is enabled, these images are located in the `<remote-storage-root-folder>/media/import/test` folder.
 
-   ![Example data - downloadable product with downloadable links]({% link images/images/data-import-downloadable-links.png %}){: .zoom}
+  ![Example data - downloadable product with downloadable links]({% link images/images/data-import-downloadable-links.png %}){: .zoom}
    _Downloadable Links_
 
--  **Downloadable sample images**—In the following example, the downloadable sample image (`white.jpg`) is located in the `<Magento-root-folder>/pub/media/import/test` folder. If remote storage is enabled, this image is located in the `<remote-storage-root-folder>/media/import/test` folder.
+- **Downloadable sample images**—In the following example, the downloadable sample image (`white.jpg`) is located in the `<Magento-root-folder>/pub/media/import/test` folder. If remote storage is enabled, this image is located in the `<remote-storage-root-folder>/media/import/test` folder.
 
-   ![Example data - downloadable product with downloadable samples]({% link images/images/data-import-downloadable-samples.png %}){: .zoom}
+  ![Example data - downloadable product with downloadable samples]({% link images/images/data-import-downloadable-samples.png %}){: .zoom}
    _Downloadable Samples_
 
 For more information about enabling and managing the Remote storage module, see [Configure remote storage][1] in the _Configuration guide_.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) improves the formatting for the[ Import Downloadable Products topic](https://docs.magento.com/user-guide/system/data-transfer-downloadable-products.html) and adds it to the navigation. This was missed in a previous PR.

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/system/data-transfer-downloadable-products.html
