### PR TITLE
Clarified Customer tax classes for VAT ID validation failure

### DIFF
--- a/src/tax/vat-validation-configure.md
+++ b/src/tax/vat-validation-configure.md
@@ -10,7 +10,7 @@ The following examples show how tax classes and rates are used for VAT ID Vali
 
 |Tax Rule #1||
 |--- |--- |
-|Customer Tax Class|Customer tax classes must include: <br/>A class for domestic customers. <br/>A class for customers with invalid VAT ID A class for customers, for whom VAT ID validation failed|
+|Customer Tax Class|Customer tax classes must include: <br />A class for domestic customers. <br />A class for customers with incorrectly formatted VAT IDs.<br />A class for customers whose VAT ID validation failed.|
 |Product Tax Class|Product tax classes must include a class for products of all types, except bundle and virtual.|
 |Tax Rate|The tax rate must include the VAT rate of the merchant’s country.|
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) clarifies the types of customer tax classes needed for a tax rule.  Changed to:

Customer tax classes must include:
A class for domestic customers.
A class for customers with incorrectly formatted VAT IDs.
A class for customers for whom VAT ID validation failed.

## Magento release version

- [x] 2.4.x

- [x] 2.3.x

## Affected documentation pages

- [Configuring VAT ID Validation](https://docs.magento.com/user-guide/v2.3/tax/vat-validation-configure.html)

## Additional information
