### PR TITLE
Fix Shipping option labels in field description table

### DIFF
--- a/src/configuration/general/b2b-features.md
+++ b/src/configuration/general/b2b-features.md
@@ -39,8 +39,8 @@ _Default B2B Payment Methods_
 ![B2B configuration - default shipping methods]({% link images/images-b2b/config-general-b2b-shipping-methods.png %}){: .zoom}
 _Default B2B Shipping Methods_
 
-|Applicable Payment Methods|Website|Determines the selection of shipping methods that are available by default to B2B buyers. Options: All Payment Methods / Specific Payment Methods|
-|Payment Methods|Website|Specifies each shipping method that is available by default to B2B buyers. <br/>**_Note:_** You can also limit the shipping methods for a specific [company account]({% link customers/account-company-create.md %}).|
+|Applicable Shipping Methods|Website|Determines the selection of shipping methods that are available by default to B2B buyers. Options: All Shipping Methods / Specific Shipping Methods|
+|Shipping Methods|Website|Specifies each shipping method that is available by default to B2B buyers. <br/>**_Note:_** You can also limit the shipping methods for a specific [company account]({% link customers/account-company-create.md %}).|
 
 ## Order Approval Configuration
 


### PR DESCRIPTION
## Purpose of this pull request

In the Shipping Options field description label, the option names have "Payment" instead of "Shipping"

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x]  B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages
- https://docs.magento.com/user-guide/v2.3/configuration/general/b2b-features.html
