### PR TITLE
Updated the Admin Usage Description section

### DIFF
--- a/src/configuration/advanced/admin.md
+++ b/src/configuration/advanced/admin.md
@@ -99,4 +99,4 @@ _Admin Usage_
 
 Field | Scope | Description
 --- | --- | ---
-Enable Admin Usage Tracking | Global | When set to **Yes**, Magento anonymously tracks how administrators interact with the Admin to help improve the user experience. This setting applies to all administrator accounts and persists after Magento upgrades.
+Enable Admin Usage Tracking | Global | When set to **Yes**, Magento anonymously tracks how administrators interact with the Admin to help improve the user experience. In addition, interactive In-Product Guidance has been added, providing Admin users with help and tips on better utilization of the product from within the Admin UI. Content such as new feature announcements, walk-through guides, onboarding information, tool tips and more will be available via this feature.

--- a/src/configuration/advanced/admin.md
+++ b/src/configuration/advanced/admin.md
@@ -99,4 +99,4 @@ _Admin Usage_
 
 Field | Scope | Description
 --- | --- | ---
-Enable Admin Usage Tracking | Global | When set to **Yes**, Magento anonymously tracks how administrators interact with the Admin to help improve the user experience. In addition, interactive In-Product Guidance has been added, providing Admin users with help and tips on better utilization of the product from within the Admin UI. Content such as new feature announcements, walk-through guides, onboarding information, tool tips and more will be available via this feature.
+Enable Admin Usage Tracking | Global | When set to **Yes**, Magento anonymously tracks how administrators interact with the Admin to help improve the user experience. Starting with Magento Commerce 2.4.2, this also enables interactive _In-Product Guidance_, providing Admin users with help and tips on better utilization of the product from within the Admin UI. Content such as new feature announcements, walk-through guides, onboarding information, tool tips, and more will be available through this feature.


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) is to update the Admin Usage description section. With the integration of gainsight (in-product guidance) within Magento Admin starting with 2.4.2 and onwards, and the fact that users only experience this value add if they consent to opt-in for Admin Usage collection, we want to update the opt-in admin usage section in the User Guides to include value information about in-product guidance. 

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.2

   Specify a patch release number, if applicable:

- [] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/configuration/advanced/admin.html#admin-usage
- ...


## Additional information

<!-- OPTIONAL - REMOVE THIS SECTION IF NOT USED. What other information can you provide? -->

- https://wiki.corp.adobe.com/pages/viewpage.action?pageId=2202684103#9146cb3c-003c-4206-8ec6-2e48be0c8982-2255742526

whatsnew
Updated the opt-in [Admin usage configuration](https://docs.magento.com/user-guide/configuration/advanced/admin.html#admin-usage) reference to include value information about in-product guidance.