### PR TITLE
Disable the jscpd linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,4 +48,5 @@ jobs:
           DEFAULT_BRANCH: master
           MARKDOWN_CONFIG_FILE: .markdownlint.json
           VALIDATE_HTML: false
+          VALIDATE_JSCPD: false
           VALIDATE_XML: false


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) disables the jscpd linter because it fails the linter check in PRs. The SuperLinter team has added the linter to the list of default linters, which we cannot control (github/super-linter#1032). We can enable it later with appropriate configuration for our projects.

