### PR TITLE
Update release notes links for 2.4.2

### DIFF
--- a/src/magento/about-this-release.md
+++ b/src/magento/about-this-release.md
@@ -11,8 +11,8 @@ redirect_from:
 
 As a best practice, we recommend that you keep your Magento installation up to date, so you can benefit from the latest advancements. Release notes provide a detailed description of the changes in each product release, with links to additional technical information, installation instructions, and support resources. To learn more about the current releases, see:
 
-- {:.ce-only}[Magento Open Source 2.4.1 Release Notes][2]{:target="_blank"}
-- {:.ee-only}[Magento Commerce 2.4.1 Release Notes][1]{:target="_blank"}
+- {:.ce-only}[Magento Open Source 2.4.2 Release Notes][2]{:target="_blank"}
+- {:.ee-only}[Magento Commerce 2.4.2 Release Notes][1]{:target="_blank"}
 
 ## Earlier releases
 
@@ -54,8 +54,8 @@ Magento 2.0.18 was the final 2.0.x release. After March 2018, Magento 2.0.x stop
 - {:.ce-only}[Magento Community 2.0 User Guide][9]{:target="_blank"}
 - {:.ee-only}[Magento Enterprise 2.0 User Guide][10]{:target="_blank"}
 
-[1]: https://devdocs.magento.com/guides/v2.4/release-notes/commerce-2-4-1.html
-[2]: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-1.html
+[1]: https://devdocs.magento.com/guides/v2.4/release-notes/commerce-2-4-2.html
+[2]: https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-2.html
 [3]: https://magento.com/products/community-edition
 [4]: https://docs.magento.com/m2/pdf/ee/Magento-Enterprise-Edition-2.1-User-Guide.pdf
 [5]: https://docs.magento.com/m2/pdf/ce/Magento-Community-Edition-2.1-User-Guide.pdf


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates links to Release Notes in preparation for GA production docs.

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable: 2.4.2

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

- https://docs.magento.com/user-guide/magento/about-this-release.html

whatsnew
Update the [About this Release](https://docs.magento.com/user-guide/magento/about-this-release.html) page with links to the 2.4.2 Release Notes.
