### PR TITLE
Add missing Commerce icon

### DIFF
--- a/src/_data/toc/customers.yml
+++ b/src/_data/toc/customers.yml
@@ -74,6 +74,7 @@ pages:
       url: "/customers/account-dashboard-billing-agreements.html"
     - label: Store Credit
       url: "/customers/account-dashboard-store-credit.html"
+      edition: ee-only
     - label: Gift Card
       url: "/customers/account-dashboard-gift-cards.html"
       edition: ee-only


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a missing icon to the TOC.

Fixes #1034.