### PR TITLE
Remove widgets on content staging

### DIFF
--- a/src/cms/content-staging.md
+++ b/src/cms/content-staging.md
@@ -21,7 +21,6 @@ When a new scheduled update is created for any of the following objects, a corre
 - [Cart Price Rules]({% link marketing/price-rule-cart-scheduled-changes.md %})
 - [CMS Pages]({% link cms/page-scheduled-changes.md %})
 - [CMS Blocks]({% link cms/blocks.md %})
-- [Widgets]({% link cms/widgets.md %})
 
 ## Content staging workflow
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes widgets from the list of content staging objects, which was pointed out as an error in devdocs internal Slack channel.

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [x] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/cms/content-staging.html


