### PR TITLE
Update linter.yml

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,10 +21,20 @@ on:
 # Set the Job #
 ###############
 jobs:
-
-  build:
-    # Name the Job
-    name: Lint Code Base
+  mdl:
+    name: mdl
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - name: Install mdl gem
+      run: gem install mdl
+    - name: Run mdl
+      run: mdl --style=_checks/styles/style-rules-prod --ignore-front-matter --git-recurse -- .
+  super-lint:
     # Set the agent to run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR) adds [mdl](https://github.com/markdownlint/markdownlint) linting to the existing workflow. The SuperLinter does not detect all violations such as [MD007](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md007---unordered-list-indentation) with different nested lists ul/ol, or [MD012](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md012---multiple-consecutive-blank-lines) with multiple consecutive spaces in code blocks. As a result, `rake test:md` fails on those slipped violations at staging and locally.