### PR TITLE
Fix Inventory Management CLI Reference Link Markup

### DIFF
--- a/src/_includes/inventory-cli.md
+++ b/src/_includes/inventory-cli.md
@@ -1,2 +1,2 @@
 {:.bs-callout-info}
-If you want to review reservations, a series of command line options are available. You can only review reservations through a command line interface. Using CLI commands may require developer assistance. See [Inventory Management CLI Reference][https://devdocs.magento.com/guides/v2.4/inventory/inventory-cli-reference.html].
+If you want to review reservations, a series of command line options are available. You can only review reservations through a command line interface. Using CLI commands may require developer assistance. See [Inventory Management CLI Reference](https://devdocs.magento.com/guides/v2.4/inventory/inventory-cli-reference.html).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) applies the correct syntax for link formatting so that the link text can be used instead of displaying the URL next to the text.

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [x] Other feature set, please specify: MSI

## Affected documentation pages

- https://docs.magento.com/user-guide/catalog/inventory-about-ssa.html
