### PR TITLE
magento/merchdocs#1126: Add the "Reset" button clarification to the Grid Layout page

### DIFF
--- a/src/stores/admin-grid-layout.md
+++ b/src/stores/admin-grid-layout.md
@@ -16,6 +16,7 @@ _Order Grid Columns_
 
    - Select the checkbox of any column you want to add to the grid.
    - Clear the checkbox of any column you want to remove from the grid.
+   - Click the **Reset** button to return the default grid view.
 
   Make sure to scroll down to see all available columns.
 

--- a/src/stores/admin-grid-layout.md
+++ b/src/stores/admin-grid-layout.md
@@ -16,7 +16,7 @@ _Order Grid Columns_
 
    - Select the checkbox of any column you want to add to the grid.
    - Clear the checkbox of any column you want to remove from the grid.
-   - Click the **Reset** button to return the default grid view.
+   - Click **Reset** to return the default grid view.
 
   Make sure to scroll down to see all available columns.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds clarification to the "Reset" button on the grid layout page.

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/stores/admin-grid-layout.html

## Additional information

<img width="1433" alt="Grid Layout | Magento 2 4 User Guide 2021-04-02 14-51-20" src="https://user-images.githubusercontent.com/79835574/113413285-f6e3e100-93c2-11eb-87e5-18bbecaa6844.png">
