### PR TITLE
Delete the square bracket from the Actions Control page.

### DIFF
--- a/src/stores/admin-actions-control.md
+++ b/src/stores/admin-actions-control.md
@@ -75,7 +75,7 @@ The checkbox in the first column of the list identifies each record that is a ta
 |List|Actions|
 |--- |--- |
 |All Customers|Delete<br/>Subscribe to Newsletter<br/>Unsubscribe from Newsletter<br/>Assign a Customer Group<br/>Edit|
-|<span class="b2b-only">Companies</span>|Set Active<br/>Block<br/>Delete<br/>Edit<br/>Convert Credit|]
+|<span class="b2b-only">Companies</span>|Set Active<br/>Block<br/>Delete<br/>Edit<br/>Convert Credit|
 
 ### Marketing
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request deletes the square bracket from the Actions Control page.

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/stores/admin-actions-control.html

## Additional information

<img width="1424" alt="Actions Control | Magento 2 4 User Guide 2021-04-02 15-01-48" src="https://user-images.githubusercontent.com/79835574/113414303-5f33c200-93c5-11eb-9b4d-d0baf1885151.png">
