### PR TITLE
magento/merchdocs#1151: Add missing items to the Role Resources page

### DIFF
--- a/src/system/permissions-role-resources.md
+++ b/src/system/permissions-role-resources.md
@@ -7,7 +7,7 @@ Access to the following resources can be assigned to a custom role. See the link
 |--- |--- |--- |
 |[Dashboard]({% link stores/admin-dashboard.md %})|||
 |[Sales]({% link sales.md %})|[Operations]({% link sales/order-management.md %})||
-||[Orders]({% link sales/orders.md %})<br/>[Invoices]({% link sales/invoices.md %})<br/>[Shipments]({% link sales/shipments.md %})<br/>[Credit Memos]({% link sales/credit-memos.md %})<br/>[Billing Agreements]({% link sales/billing-agreements.md %})<br/>[Transactions]({% link sales/transactions.md %})|
+||<span class="b2b-only">[Quotes]({% link sales/quotes.md %})</span><br/>[Orders]({% link sales/orders.md %})<br/>[Invoices]({% link sales/invoices.md %})<br/>[Shipments]({% link sales/shipments.md %})<br/>[Credit Memos]({% link sales/credit-memos.md %})<br/>[Billing Agreements]({% link sales/billing-agreements.md %})<br/><span class="ee-only">[Returns]({% link sales/returns.md %})</span><br/>[Transactions]({% link sales/transactions.md %})|
 ||<span class="ee-only">[Archive]({% link system/action-log-archive.md %})</span>||
 ||[Shopping Cart Management]({% link sales/cart.md %})||
 |[Catalog]({% link catalog/catalog-menu.md %})|<span class="ee-only">[Category Permissions]({% link catalog/categories.md %})||
@@ -26,12 +26,14 @@ Access to the following resources can be assigned to a custom role. See the link
 ||[User Content]({% link catalog/settings-advanced-product-reviews.md %}) | [All Reviews]({% link catalog/settings-advanced-product-reviews.md %}) <br/>[Pending Reviews]({% link marketing/magento-product-reviews-moderate.md %}) <br/>[Yotpo Reviews]({% link marketing/yotpo-reviews-intro.md %})||
 |[Content]({% link content.md %}) | [Elements]({% link cms/content-elements.md %}) | [Pages]({% link cms/pages.md %})<br/><span class="ee-only">[Hierarchy]({% link cms/page-hierarchy.md %})</span><br/>[Blocks]({% link cms/blocks.md %})<br/><span class="ee-only">[Dynamic Blocks]({% link cms/dynamic-blocks.md %})</span><br/>[Widgets]({% link cms/widgets.md %})<br/>[Media Gallery]({% link cms/media-storage.md %})||
 ||[Design]({% link design/design-theme.md %}) | [Themes]({% link design/themes.md %})<br/>[Schedule]({% link design/schedule.md %})||
+||<span class="ee-only">[Content Staging]({% link cms/content-staging.md %})</span><br />
 |[Reports]({% link reports.md %}) | [Marketing]({% link reports/marketing-reports.md %})|Shopping Cart<br />Search Terms<br />Newsletter Problem Reports||
 ||[Reviews]({% link reports/review-reports.md %})<br />
 ||[Sales]({% link reports/sales-reports.md %})||
 ||<span class="ee-only">System Insights|[Site-Wide Analysis Tool]({% link reports/site-wide-analysis-tool.md %})|
 ||[Customers]({% link reports/customer-reports.md %})<br/>[Products]({% link reports/product-reports.md %})<br/><span class="ee-only">[Private Sales]({% link marketing/events-private-sales.md %})<br />[Statistics]({% link reports/statistics.md %})<br />[Business Intelligence]({% link reports/business-intelligence.md %})||
 |[Stores]({% link stores/stores.md %}) | [Settings]({% link stores/stores-menu.md %}) | [All Stores]({% link stores/stores-all-stores.md %})<br/>[Configuration]({% link stores/configuration-overview.md %})<br/>[Terms and Conditions]({% link sales/terms-and-conditions.md %})<br/>[Order Status]({% link sales/order-status.md %})||
+||[Inventory]({% link configuration/catalog/inventory.md %})|[Sources]({% link catalog/sources.md %})<br/>Stocks||
 ||[Taxes]({% link tax/taxes.md %})|||
 ||[Currency]({% link stores/currency.md %})|[Currency Rates]({% link stores/currency-configuration.md %})<br/>[Currency Symbols]({% link stores/currency-symbols.md %})||
 ||[Attributes]({% link stores/attributes.md %})|[Product]({% link stores/attributes-product.md %})<br/>[Update Attributes]({% link stores/attribute-product-create.md %})<br/>[Attribute Set]({% link stores/attribute-sets.md %})<br/>[Ratings]({% link stores/attributes-rating.md %})|


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds missing items to the Role Resources page

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/system/permissions-role-resources.html
