### PR TITLE
Add missing cache types to the Cache Management page

### DIFF
--- a/src/system/cache-management.md
+++ b/src/system/cache-management.md
@@ -100,16 +100,18 @@ Configuration | Various XML configurations that were collected across modules an
 Layouts | Layout building instructions. | `LAYOUT_GENERAL_CACHE_TAG`
 Blocks HTML output | Page blocks HTML. | `BLOCK_HTML`
 Collections Data | Collection data files.  | `COLLECTION_DATA`
-Reflection Data | Clears API interface reflection data, that typically is generated during runtime. |
+Reflection Data | Clears API interface reflection data, that typically is generated during runtime. | `REFLECTION`
 Database DDL operations | Results of DDL queries, such as describing tables or indexes.  | `DB_DDL`
 Compiled Config | Results of code compilation. | `COMPILED_CONFIG`
 EAV types and attributes | Entity types declaration cache. | `EAV`
-Customer Notification | Temporary notifications that appear in the user interface.
+Customer Notification | Temporary notifications that appear in the user interface. | `CUSTOMER_NOTIFICATION`
 Integrations Configuration | Integration configuration file. | `INTEGRATION`
 Integrations API Configuration | Integrations API configuration file. | `INTEGRATION_API_CONFIG`
 Page Cache | Full page caching. | `FPC`
 Translations | Translation files. | `TRANSLATE`
 Web Services Configuration | REST and SOAP configurations, generated WSDL file. | `WEBSERVICE`
+Target Rule | Target Rule Index | `TARGET_RULE`
+Vertex | Vertex tax calculation data | `VERTEX`
 
 ## Cache Management Role Resources
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds missing cache types to the Cache Management page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/system/cache-management.html