### PR TITLE
Add Gift Card Email Sender actions

### DIFF
--- a/src/catalog/product-gift-card-account-configuration.md
+++ b/src/catalog/product-gift-card-account-configuration.md
@@ -26,10 +26,10 @@ The Gift Card configuration establishes the default settings for all gift cards 
 
    - Set **Gift Card Template** to the template you want to use for the gift card.
    
-   |General Contact|The email address associated with the General Contact identity.|
-   |Sales Representative|The email address associated with the Sales Representative identity.|
-   |Customer Support|The email address associated with the Customer Support identity.|
-   |Custom Email 1,2|The email address associated with the Customs identities.|
+      |General Contact|The email address associated with the General Contact identity. |
+      |Sales Representative|The email address associated with the Sales Representative identity. |
+      |Customer Support|The email address associated with the Customer Support identity. |
+      |Custom Email 1,2|The email address associated with the Customs identities. |
 
    See [Store Email Addresses]({% link configuration/general/store-email-addresses.md %}) ​for specific configuration fields and options.
 

--- a/src/catalog/product-gift-card-account-configuration.md
+++ b/src/catalog/product-gift-card-account-configuration.md
@@ -26,14 +26,7 @@ The Gift Card configuration establishes the default settings for all gift cards 
 
    - Set **Gift Card Template** to the template you want to use for the gift card.
 
-|Action|Description|
-|--- |--- |
-|General Contact|The email address associated with the General Contact identity. |
-|Sales Representative|The email address associated with the Sales Representative identity. |
-|Customer Support|The email address associated with the Customer Support identity. |
-|Custom Email 1,2|The email address associated with the Customs identities. |
-
-See [Store Email Addresses]({% link configuration/general/store-email-addresses.md %}) ​for specific configuration fields and options.
+See [Store Email Addresses]({% link configuration/general/store-email-addresses.md %}) for specific configuration fields and options.
 
 ## Step 2: Complete the general settings
 

--- a/src/catalog/product-gift-card-account-configuration.md
+++ b/src/catalog/product-gift-card-account-configuration.md
@@ -25,6 +25,13 @@ The Gift Card configuration establishes the default settings for all gift cards 
    - Set **Gift Card Email Sender** to the store identity to appear as the sender of the gift cards.
 
    - Set **Gift Card Template** to the template you want to use for the gift card.
+   
+   |General Contact|The email address associated with the General Contact identity.|
+   |Sales Representative|The email address associated with the Sales Representative identity.|
+   |Customer Support|The email address associated with the Customer Support identity.|
+   |Custom Email 1,2|The email address associated with the Customs identities.|
+
+   See [Store Email Addresses]({% link configuration/general/store-email-addresses.md %}) ​for specific configuration fields and options.
 
 ## Step 2: Complete the general settings
 

--- a/src/catalog/product-gift-card-account-configuration.md
+++ b/src/catalog/product-gift-card-account-configuration.md
@@ -25,13 +25,15 @@ The Gift Card configuration establishes the default settings for all gift cards 
    - Set **Gift Card Email Sender** to the store identity to appear as the sender of the gift cards.
 
    - Set **Gift Card Template** to the template you want to use for the gift card.
-   
-      |General Contact|The email address associated with the General Contact identity. |
-      |Sales Representative|The email address associated with the Sales Representative identity. |
-      |Customer Support|The email address associated with the Customer Support identity. |
-      |Custom Email 1,2|The email address associated with the Customs identities. |
 
-   See [Store Email Addresses]({% link configuration/general/store-email-addresses.md %}) ​for specific configuration fields and options.
+|Action|Description|
+|--- |--- |
+|General Contact|The email address associated with the General Contact identity. |
+|Sales Representative|The email address associated with the Sales Representative identity. |
+|Customer Support|The email address associated with the Customer Support identity. |
+|Custom Email 1,2|The email address associated with the Customs identities. |
+
+See [Store Email Addresses]({% link configuration/general/store-email-addresses.md %}) ​for specific configuration fields and options.
 
 ## Step 2: Complete the general settings
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds Gift Card Email Sender actions to the "Configuring Gift Card Accounts" page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/catalog/product-gift-card-account-configuration.html