### PR TITLE
magento/merchdocs#1168: Sales | The /sales/order-ship.html page isn't displayed in the sidebar

### DIFF
--- a/src/_data/toc/sales.yml
+++ b/src/_data/toc/sales.yml
@@ -109,6 +109,8 @@ pages:
       url: "/sales/order-workflow.html"
     - label: Processing an Order
       url: "/sales/order-processing.html"
+    - label: Shipping an Order
+      url: "/sales/order-ship.html"
     - label: Order Status
       url: "/sales/order-status.html"
       children:


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

Fix pull request fixes https://github.com/magento/merchdocs/issues/1168

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/sales/order-ship.html


<!-- OPTIONAL - REMOVE THIS SECTION IF NOT USED. What other information can you provide? -->

<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`

`master` is the default branch. Merged pull requests to `master` go live on the site automatically. Any requested changes to content on the `master` branch must be related to the released codebase. Any content related to future releases goes in a release integration branch.

See Contribution guidelines (https://github.com/magento/merchdocs/blob/master/.github/CONTRIBUTING.md) and wiki (https://github.com/magento/merchdocs/wiki) for more information.
-->
