### PR TITLE
Add the Allow Zero GrandTotal field to the Sales page

### DIFF
--- a/src/configuration/sales/sales.md
+++ b/src/configuration/sales/sales.md
@@ -36,11 +36,11 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Sale
 |--- |--- |--- |
 |Allow Reorder|Store View|Determines if the customers can reorder from their accounts. Options: Yes / No|
 
-## Allow Zero GrandTotal
+## Allow Zero Grand Total
 
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |
-|Allow Zero GrandTotal for Creditmemo|Website|Determines the possibility of creating a Creditmemo with a Zero GrandTotal. Options: Yes / No|
+|Allow Zero Grand Total for Credit Memo|Website|Determines the possibility of creating a Credit Memo with a Zero Grand Total. Options: Yes / No|
 
 ## Invoice and Packing Slip Design
 

--- a/src/configuration/sales/sales.md
+++ b/src/configuration/sales/sales.md
@@ -36,6 +36,12 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Sale
 |--- |--- |--- |
 |Allow Reorder|Store View|Determines if the customers can reorder from their accounts. Options: Yes / No|
 
+## Allow Zero GrandTotal
+
+|Field|[Scope]({% link configuration/scope.md %})|Description|
+|--- |--- |--- |
+|Allow Zero GrandTotal for Creditmemo|Website|Determines the possibility of creating a Creditmemo with a Zero GrandTotal. Options: Yes / No|
+
 ## Invoice and Packing Slip Design
 
 ![]({% link images/images/config-sales-sales-invoice-packing-slip-design.png %}){: .zoom}


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the Allow Zero GrandTotal field to the Sales page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/configuration/sales/sales.html