### PR TITLE
Add Inventory Indexer Settings for the Inventory page

### DIFF
--- a/src/configuration/catalog/inventory.md
+++ b/src/configuration/catalog/inventory.md
@@ -47,6 +47,12 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Cata
 |--- |--- |--- |
 |Run asynchronously|Global|Determines if you run bulk operations asynchronously for mass product actions including bulk [assign sources]({% link catalog/inventory-bulk-assign-sources.md %}), [unassign sources]({% link catalog/inventory-bulk-unassign-sources.md %}), and [transfer inventory to source]({% link catalog/inventory-bulk-transfer-inventory.md %}). It collects bulk actions up to the Asynchronous batch size, then runs those actions. This feature is disabled by default. We recommend reviewing your performance with bulk actions before enabling. Options: <br/>**Yes** - Runs all bulk operations for Inventory Management asynchronously. To enable, you must configure an asynchronous queue manager. <br/>**No** - Default. Does not run bulk operations asynchronously.|
 
+## Inventory Indexer Settings
+
+|Field|[Scope]({% link configuration/scope.md %})|Description|
+|--- |--- |--- |
+|Stock/Source reindex strategy|Global|Determines the strategy to use for the stock/source reindexing. Options: Synchronous / Asynchronous. An asynchronous queue manager must be configured for async mode.|
+
 ## Distance Provider for Distance Based SSA
 
 ![]({% link images/images/config-catalog-catalog-inventory-distance-provider.png %}){: .zoom}

--- a/src/configuration/catalog/inventory.md
+++ b/src/configuration/catalog/inventory.md
@@ -51,7 +51,7 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Cata
 
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |
-|Stock/Source reindex strategy|Global|Determines the strategy to use for the stock/source reindexing. Options: Synchronous / Asynchronous. An asynchronous queue manager must be configured for async mode.|
+|Stock/Source reindex strategy|Global|Determines the strategy used for stock/source reindexing. Options: Synchronous / Asynchronous. An asynchronous queue manager must be configured for async mode.|
 
 ## Distance Provider for Distance Based SSA
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the Inventory Indexer Settings block for the Inventory page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/configuration/catalog/inventory.html