### PR TITLE
Remove the "Magento Commerce only" tag from the Customer Accounts page

### DIFF
--- a/src/customers/customer-account.md
+++ b/src/customers/customer-account.md
@@ -12,7 +12,7 @@ The header of every page in your store extends an invitation for shoppers to _Lo
 Customers can access their account by clicking the **My Account** link in the header of the store. From their account, customers can view and modify information, including past and current addresses, billing and shipping preferences, newsletter subscriptions, wish list, and more.
 
 ![]({% link images/images-ee/customer-account-dashboard-my-account.png %}){: .zoom}
-_My Account_{:.ee-only}
+_My Account_
 
 {:.b2b-only}
 ## Account types


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes the "Magento Commerce only" tag from the Customer Accounts page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/customers/customer-account.html