### PR TITLE
Add missing links to the Role Resources page

### DIFF
--- a/src/system/permissions-role-resources.md
+++ b/src/system/permissions-role-resources.md
@@ -11,8 +11,8 @@ Access to the following resources can be assigned to a custom role. See the link
 ||<span class="ee-only">[Archive]({% link system/action-log-archive.md %})</span>||
 ||[Shopping Cart Management]({% link sales/cart.md %})||
 |[Catalog]({% link catalog/catalog-menu.md %})|<span class="ee-only">[Category Permissions]({% link catalog/categories.md %})||
-||[Inventory]({% link catalog/products.md %})|Products<br/>Categories|
-||<span class="b2b-only">[Shared Catalog]({% link catalog/catalog-shared.md %})</span>| Manage Shared Catalog|
+||[Inventory]({% link catalog/products.md %})|[Products]({% link catalog/products.md %})<br/>[Categories]({% link catalog/categories.md %})|
+||<span class="b2b-only">[Shared Catalog]({% link catalog/catalog-shared.md %})</span>|[Manage Shared Catalog]({% link catalog/catalog-shared-manage.md %})|
 |[Customers]({% link customers.md %}) | [All Customers]({% link customers/customers-all.md %})<br/>[Now Online]({% link customers/now-online.md %})<br/>[Customer Groups]({% link customers/customer-groups.md %})<br/><span class="ee-only">[Segments]({% link marketing/customer-segments.md %})<br/>||
 ||[Login as Customer]({% link customers/login-as-customer.md %})|Allow Login as Customer Button<br/><span class="ee-only">View Login as Customer Log</span>|
 ||<span class="b2b-only">[Companies]({% link customers/account-companies.md %})</span>| [ Manage Companies]({% link customers/account-company-manage.md %}) <br/>Add New Company <br/>Delete Company <br/>Reimburse Balance |
@@ -27,21 +27,21 @@ Access to the following resources can be assigned to a custom role. See the link
 |[Content]({% link content.md %}) | [Elements]({% link cms/content-elements.md %}) | [Pages]({% link cms/pages.md %})<br/><span class="ee-only">[Hierarchy]({% link cms/page-hierarchy.md %})</span><br/>[Blocks]({% link cms/blocks.md %})<br/><span class="ee-only">[Dynamic Blocks]({% link cms/dynamic-blocks.md %})</span><br/>[Widgets]({% link cms/widgets.md %})<br/>[Media Gallery]({% link cms/media-storage.md %})||
 ||[Design]({% link design/design-theme.md %}) | [Themes]({% link design/themes.md %})<br/>[Schedule]({% link design/schedule.md %})||
 ||<span class="ee-only">[Content Staging]({% link cms/content-staging.md %})</span><br />
-|[Reports]({% link reports.md %}) | [Marketing]({% link reports/marketing-reports.md %})|Shopping Cart<br />Search Terms<br />Newsletter Problem Reports||
+|[Reports]({% link reports.md %}) | [Marketing]({% link reports/marketing-reports.md %})|Shopping Cart<br />[Search Terms]({% link marketing/search-terms-report.md %})<br />Newsletter Problem Reports||
 ||[Reviews]({% link reports/review-reports.md %})<br />
 ||[Sales]({% link reports/sales-reports.md %})||
 ||<span class="ee-only">System Insights|[Site-Wide Analysis Tool]({% link reports/site-wide-analysis-tool.md %})|
 ||[Customers]({% link reports/customer-reports.md %})<br/>[Products]({% link reports/product-reports.md %})<br/><span class="ee-only">[Private Sales]({% link marketing/events-private-sales.md %})<br />[Statistics]({% link reports/statistics.md %})<br />[Business Intelligence]({% link reports/business-intelligence.md %})||
 |[Stores]({% link stores/stores.md %}) | [Settings]({% link stores/stores-menu.md %}) | [All Stores]({% link stores/stores-all-stores.md %})<br/>[Configuration]({% link stores/configuration-overview.md %})<br/>[Terms and Conditions]({% link sales/terms-and-conditions.md %})<br/>[Order Status]({% link sales/order-status.md %})||
-||[Inventory]({% link configuration/catalog/inventory.md %})|[Sources]({% link catalog/sources.md %})<br/>Stocks||
+||[Inventory]({% link configuration/catalog/inventory.md %})|[Sources]({% link catalog/sources.md %})<br/>[Stocks]({% link catalog/inventory-stock.md %})||
 ||[Taxes]({% link tax/taxes.md %})|||
 ||[Currency]({% link stores/currency.md %})|[Currency Rates]({% link stores/currency-configuration.md %})<br/>[Currency Symbols]({% link stores/currency-symbols.md %})||
 ||[Attributes]({% link stores/attributes.md %})|[Product]({% link stores/attributes-product.md %})<br/>[Update Attributes]({% link stores/attribute-product-create.md %})<br/>[Attribute Set]({% link stores/attribute-sets.md %})<br/>[Ratings]({% link stores/attributes-rating.md %})|
-||Other Settings|[Customer Groups]({% link customers/customer-groups.md %})|
+||[Other Settings]({% link stores/stores-menu.md %})|[Customer Groups]({% link customers/customer-groups.md %})|
 |[System]({% link system/system.md %}) | [Data Transfer]({% link system/data-transfer.md %}) | [Import]({% link system/data-import.md %})<br/>[Export]({% link system/data-export.md %})<br/>[Import/Export Tax Rates]({% link system/data-transfer-tax-rates.md %})<br/>[Import History]({% link system/data-import-history.md %})||
 ||[Magento Connect]({% link magento/magento-marketplace.md %}) | Connect Manager<br/>Package Extensions||
 ||[Tools]({% link system/tools.md %}) | [Cache Management]({% link system/cache-management.md %})<br/>[Backups]({% link system/backups.md %})<br/>[Index Management]({% link system/index-management.md %})<br/>[Change Indexer Mode]({% link system/index-management.md %}) ||
 ||[Permissions]({% link system/permissions.md %}) | [All Users]({% link system/permissions-users-all.md %})<br/>[Locked Users]({% link system/permissions-locked-users.md %})<br/>[User Roles]({% link system/permissions-user-roles.md %})|
 |<span class="ee-only">[Action Log]({% link system/action-log.md %})</span>| [Report]({% link system/action-log.md %})<br/>[Archive]({% link system/action-log-archive.md %})|
-||Other Settings|[Notifications]({% link stores/admin-message-inbox.md %})<br/>[Custom Variables]({% link marketing/variables-custom.md %})<br/>[Manage Encryption Key]({% link system/encryption-key.md %})||
+||[Other Settings]({% link system/system-menu.md %})|[Notifications]({% link stores/admin-message-inbox.md %})<br/>[Custom Variables]({% link marketing/variables-custom.md %})<br/>[Manage Encryption Key]({% link system/encryption-key.md %})||
 |[Global Search]({% link stores/admin-global-search.md %})|||


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds missing links to the Role Resources page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/system/permissions-role-resources.html