### PR TITLE
Replacing the wrong 'Shared Catalogs' link to correct one

### DIFF
--- a/src/customers/customer-groups.md
+++ b/src/customers/customer-groups.md
@@ -4,7 +4,7 @@ title: Customer Groups
 
 Customer groups determine which discounts are available and the tax class that is associated with the group. The default customer groups are General, Not Logged In, and Wholesale.
 
-- {:.b2b-only}The selection of customer groups includes all regular customer groups, and shared catalogs, even if [Shared Catalogs]({% link catalog/catalog-shared.md %}) is not enabled in the configuration. Only one customer group or shared catalog can be assigned to a [company]({% link customers/account-companies.md %}) at a time.
+- {:.b2b-only}The selection of customer groups includes all regular customer groups and shared catalogs, even if **Shared Catalogs** is not enabled in the configuration. See [Configure B2B features]({% link stores/b2b-features.md %}) to enable shared catalogs. Only one customer group or shared catalog can be assigned to a [company]({% link customers/account-companies.md %}) at a time.
 
 ![]({% link images/images/customer-groups.png %}){: .zoom}
 _Customer Groups_

--- a/src/customers/customer-groups.md
+++ b/src/customers/customer-groups.md
@@ -4,7 +4,7 @@ title: Customer Groups
 
 Customer groups determine which discounts are available and the tax class that is associated with the group. The default customer groups are General, Not Logged In, and Wholesale.
 
-- {:.b2b-only}The selection of customer groups includes all regular customer groups, and shared catalogs, even if [Shared Catalogs]({% link stores/b2b-features.md %}) is not enabled in the configuration. Only one customer group or shared catalog can be assigned to a [company]({% link customers/account-companies.md %}) at a time.
+- {:.b2b-only}The selection of customer groups includes all regular customer groups, and shared catalogs, even if [Shared Catalogs]({% link catalog/catalog-shared.md %}) is not enabled in the configuration. Only one customer group or shared catalog can be assigned to a [company]({% link customers/account-companies.md %}) at a time.
 
 ![]({% link images/images/customer-groups.png %}){: .zoom}
 _Customer Groups_


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

According to the description, the link "Shared Catalogs" should open the topic page "Share Catalogs", but it opens a page for a general description of B2B functions.
This pull request (PR) replaces the wrong link to correct one on the Customer Groups topic page 


## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/customers/customer-groups.html
