### PR TITLE
Deleting a "Custom Pricing" topic that duplicates another same topic in the Catalog section

### DIFF
--- a/src/_data/toc/catalog.yml
+++ b/src/_data/toc/catalog.yml
@@ -127,9 +127,6 @@ pages:
         url: "/catalog/product-price-minimum-advertised-logic.html"
       - label: Configuring MAP
         url: "/catalog/product-price-minimum-advertised-configure.html"
-    - label: Custom Pricing
-      url: "/catalog/product-price-custom.html"
-      edition: b2b-only
 - label: Managing Inventory
   url: "/catalog/inventory-management.html"
   children:

--- a/src/catalog/product-price-custom.md
+++ b/src/catalog/product-price-custom.md
@@ -1,9 +1,0 @@
----
-b2b_only: true
-title: Custom Pricing
----
-
-Custom pricing is available by using a shared catalog, which make it possible to set different product pricing for a specific company or website. For more information, see [Shared Catalogs]({% link catalog/catalog-shared.md %}).
-
-![]({% link images/images-b2b/catalog-shared-set-custom-prices-discount.png %}){: .zoom}
-[_Set Custom Prices_]({% link catalog/catalog-shared-pricing-structure.md %})


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

There is a detailed description of the topic "Custom Pricing", which is in the "Shared Catalog" block.
There is also a topic that, in fact, does not have much meaning and semantic load, but simply redirects to the topics below in the same section. Therefore, it would be more rational to delete the duplicate.
![image](https://user-images.githubusercontent.com/78729171/116394900-205e2400-a82c-11eb-90b3-173c151ae2f7.png)

This pull request (PR) removes a "Custom Pricing" topic that duplicates another same topic in the Catalog section

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/catalog/product-price-custom.html
- https://docs.magento.com/user-guide/catalog/catalog-shared-custom-pricing-update.html
