### PR TITLE
Add a link to the dashboard page to redirect to the advanced reporting page

### DIFF
--- a/src/stores/admin-dashboard.md
+++ b/src/stores/admin-dashboard.md
@@ -13,7 +13,7 @@ _Dashboard_
 Advanced Reporting displays a personalized dashboard based on your product, order, and customer data. For more extensive analysis, see [Magento Business Intelligence][1].
 
 ![]({% link images/images/dashboard-advanced-reporting.png %}){: .zoom}
-_Advanced Reporting_
+[_Advanced Reporting_]({% link reports/advanced-reporting.md %})
 
 ## Configure the dashboard
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds a link to the dashboard page to redirect to the advanced reporting page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

user-guide/stores/admin-dashboard.html?itm_source=merchdocs&itm_medium=search_page&itm_campaign=federated_search&itm_term=Advanced%20Reporting