### PR TITLE
Update link the Archive order link on the Sales Menu page

### DIFF
--- a/src/sales/sales-menu.md
+++ b/src/sales/sales-menu.md
@@ -50,4 +50,4 @@ The [Transactions]({% link sales/transactions.md %}) page lists all payment acti
 {:.ee-only}
 ### Archive
 
-(Archive option must be enabled) [Archiving orders]({% link sales/transactions.md %}) and other sales documents on a regular basis improves performance and keeps your workspace free of unnecessary information.
+(Archive option must be enabled) [Archiving orders]({% link sales/order-archive.md %}) and other sales documents on a regular basis improves performance and keeps your workspace free of unnecessary information.

--- a/src/stores/admin-dashboard.md
+++ b/src/stores/admin-dashboard.md
@@ -13,7 +13,7 @@ _Dashboard_
 Advanced Reporting displays a personalized dashboard based on your product, order, and customer data. For more extensive analysis, see [Magento Business Intelligence][1].
 
 ![]({% link images/images/dashboard-advanced-reporting.png %}){: .zoom}
-_Advanced Reporting_
+[_Advanced Reporting_]({% link reports/advanced-reporting.md %})
 
 ## Configure the dashboard
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request:
- updates link the Archive order link on the Sales Menu page
- adds a link to the dashboard page to redirect to the advanced reporting page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/sales/sales-menu.html