### PR TITLE
Add options to the Tax Class for Gift Options field on the Gift Options Tax page

### DIFF
--- a/src/sales/gift-options-tax.md
+++ b/src/sales/gift-options-tax.md
@@ -16,7 +16,14 @@ Gift wrapping and printed gift card prices can be configured to include or exclu
    ![]({% link images/images/config-sales-tax-tax-classes.png %}){: .zoom}
    _Tax class configuration_
 
-1. Set **Tax Class for Gift Options** to the applicable tax class.
+1. Set **Tax Class for Gift Options** to to one of the following:
+
+   - `Taxable Goods`
+   - `Refund Adjustments`
+   - `Gift Options`
+   - `Order Gift Wrapping`
+   - `Printed Gift Card`
+   - `Reward Points`
 
 1. Expand ![]({% link images/images/btn-expand.png %}) the **Orders, Invoices, Credit Memos Display Settings** section.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds options to the Tax Class for Gift Options field on the Gift Options Tax page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/sales/gift-options-tax.html