### PR TITLE
Column description for the Shipment page

### DIFF
--- a/src/sales/shipments.md
+++ b/src/sales/shipments.md
@@ -8,3 +8,28 @@ Magento supports partial and complete order shipment, with additional options av
 
 ![]({% link images/images/sales-shipments.png %}){: .zoom}
 _Shipments grid_
+
+## Column descriptions
+
+|Control|Description|
+|--- |--- |
+|Select|Select the checkbox to select the quote(s) to be subject to an action, or use the selection control in the column header. Options: Select All / Deselect All|
+|Shipment|A unique, sequential number that is assigned when a new shipment is saved for the first time|
+|Ship Date|Shipping date|
+|Order|Unique serial number of the order|
+|Order Date|The date and time the order was placed|
+|Ship-to Name|The name of the person to whom the order is to be shipped|
+|Total Quantity|Total quantity of items to ship|
+|Action|View opens the shipment in edit mode|
+
+### Additional Columns Available
+
+|Order Status|Indicates the order status|
+|Purchased From|Indicates the website, store, and store view where the order was placed|
+|Customer Name|The name of the customer or buyer who placed the order|
+|Email|The email address of a registered customer|
+|Customer Group|The name of the customer group or shared catalog to which the customer is assigned|
+|Billing Address|The name of the customer or buyer who placed the order|
+|Shipping Address|The name of the person to whose attention the order should be shipped|
+|Payment Method|The method of payment to be used for the order|
+|Shipping Information|The method that is to be used to ship the order|

--- a/src/sales/shipments.md
+++ b/src/sales/shipments.md
@@ -13,7 +13,7 @@ _Shipments grid_
 
 |Control|Description|
 |--- |--- |
-|Select|Select the checkbox to select the quote(s) to be subject to an action, or use the selection control in the column header. Options: Select All / Deselect All|
+|Select|Select the checkbox for each quote to be subject to an action, or use the selection control in the column header. Options: Select All / Deselect All|
 |Shipment|A unique, sequential number that is assigned when a new shipment is saved for the first time|
 |Ship Date|Shipping date|
 |Order|Unique serial number of the order|
@@ -22,7 +22,7 @@ _Shipments grid_
 |Total Quantity|Total quantity of items to ship|
 |Action|View opens the shipment in edit mode|
 
-### Additional Columns Available
+### Additional columns
 
 |Order Status|Indicates the order status|
 |Purchased From|Indicates the website, store, and store view where the order was placed|


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds missing columns description for the Shipment page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/sales/shipments.html