### PR TITLE
Column description for the Invoices page

### DIFF
--- a/src/sales/invoices.md
+++ b/src/sales/invoices.md
@@ -18,7 +18,7 @@ _Invoices grid_
 |Order|Unique serial number of the order|
 |Order Date|The date and time the order was placed|
 |Bill-to Name|The name of the person who is responsible to pay for the order|
-|Status|Invoice Status|
+|Status|Invoice status|
 |Grand Total (Base)|The grand total of the order|
 |Grand Total (Purchased)|The grand total of products purchased in the order|
 |Action|View opens the invoice in edit mode|

--- a/src/sales/invoices.md
+++ b/src/sales/invoices.md
@@ -8,3 +8,30 @@ On the _Admin_ sidebar, go to **Sales** > _Operations_ > **Invoices** to open th
 
 ![]({% link images/images/sales-invoices.png %}){: .zoom}
 _Invoices grid_
+
+## Column descriptions
+
+|Control|Description|
+|--- |--- |
+|Invoice|A unique, sequential number that is assigned when a new invoice is saved for the first time|
+|Invoice Date|Date of invoice|
+|Order|Unique serial number of the order|
+|Order Date|The date and time the order was placed|
+|Bill-to Name|The name of the person who is responsible to pay for the order|
+|Status|Invoice Status|
+|Grand Total (Base)|The grand total of the order|
+|Grand Total (Purchased)|The grand total of products purchased in the order|
+|Action|View opens the invoice in edit mode|
+
+### Additional Columns Available
+
+|Purchased From|Indicates the website, store, and store view where the order was placed|
+|Billing Address|The address of the customer or buyer who placed the order|
+|Shipping Address|The address of the person to whose attention the order should be shipped|
+|Customer Name|The name of the customer or buyer who placed the order|
+|Email|The email address of a registered customer|
+|Customer Group|The name of the customer group or shared catalog to which the customer is assigned|
+|Payment Method|The method of payment to be used for the invoice|
+|Shipping Information|The method that is to be used to ship the order|
+|Subtotal|The order subtotal, without shipping and handling, and tax|
+|Shipping and Handling|The amount charged for shipping and handling|


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds missing columns description for the Invoices page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/sales/invoices.html