### PR TITLE
Removed misleading infromation from adobe stock configuration instructions

### DIFF
--- a/src/cms/adobe-stock.md
+++ b/src/cms/adobe-stock.md
@@ -35,9 +35,6 @@ Configuring the Adobe Stock integration for Magento is a two-step process: [crea
 
 1. Select **Adobe Stock** from the integrations list and click **Continue**.
 
-   {:.bs-callout-warning}
-   At this time, _do not_ use the Adobe Stock service on this screen.
-
 1. Select **Oauth 2.0 Web** platform.
 
 1. Specify the **Redirect URI**.


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes the block with incorrect information remaining after https://github.com/magento/merchdocs/pull/786

## Magento release version

All releases starting from 2.3.5

## Product editions

All editions

## Affected documentation pages

- https://docs.magento.com/user-guide/cms/adobe-stock.html
