### PR TITLE
Add callout tip for USPS Gateway URL about HTTPS endpoint

### DIFF
--- a/src/shipping/usps.md
+++ b/src/shipping/usps.md
@@ -25,6 +25,9 @@ You can also open a [USPS Web Tools][1] account. After you complete the registra
 
 1. If needed, enter the **Gateway URL** to access USPS shipping rates.
 
+   {:.bs-callout-info}
+   Effective June 24th, 2021, Web Tools will remove support for all unsecure HTTP endpoints. After this change, all Web Tools API requests to an unsecure HTTP endpoint will fail. Make sure your **Gateway URL** is used with secure **HTTPS** endpoint.
+
    The field is preset by default, and normally does not need to be changed.
 
 1. Enter a **Title** for this shipping method that will appear during checkout.
@@ -35,9 +38,6 @@ You can also open a [USPS Web Tools][1] account. After you complete the registra
 
    |Development|Runs USPS in a test environment. After running USPS in a development environment, make sure to return later and set Mode to `Live`.|
    |Live|Runs USPS in a live production environment.|
-
-   ![]({% link images/images/config-sales-shipping-methods-usps-account-settings.png %}){: .zoom}
-   _[USPS Account Settings]({% link configuration/sales/delivery-methods.md %})_
 
 ## Step 3: Complete the packaging description
 


### PR DESCRIPTION
## Purpose of this pull request

<!-- REQUIRED Describe the goal and the type of changes this pull request covers. Tell us what changes are you making and why. -->

This pull request (PR):
- fixes https://github.com/magento/merchdocs/issues/1204
- delete the wrong screen 

## Magento release version

<!-- Use this section to indicate which Magento release(s) are affected by the content changes. -->

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

<!-- REQUIRED List HTML links for affected pages on https://docs.magento.com -->

- https://docs.magento.com/user-guide/shipping/usps.html

## Links to Magento source code or PRs

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento codebase repository or a code PR, add it here. -->

- https://www.usps.com/business/web-tools-apis/2021-web-tools-release-notes.pdf
