### PR TITLE
Add the letter "t" to the word "the" on the Creating a Shipment page

### DIFF
--- a/src/sales/shipments-create.md
+++ b/src/sales/shipments-create.md
@@ -48,7 +48,7 @@ For each line item in the order, modify the **Qty to Ship** as needed.
 |Button|Description|
 |--- |--- |
 |<span class="btn">Back</span>|Closes the New Shipment form, and returns to the order|
-|<span class="btn">Submit Shipment</span>|Adds he shipment for the order.|
+|<span class="btn">Submit Shipment</span>|Adds the shipment for the order.|
 |<span class="btn">Reset</span>|Restores all fields to original values.|
 
 ## Field descriptions


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the letter "t" to the word "the" on the Creating a Shipment page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/sales/shipments-create.html?itm_source=merchdocs&itm_medium=quick_search&itm_campaign=federated_search&itm_term=