### PR TITLE
Describe how to add a product with configuration for the Managing a Shopping Cart page

### DIFF
--- a/src/sales/shopping-assisted-cart-manage.md
+++ b/src/sales/shopping-assisted-cart-manage.md
@@ -65,7 +65,7 @@ _Shopping Cart in in the customer account_
 
 ### Add a product with configuration
 
-There are 4 types of products that need to be configured before adding to the cart: `Bundle Product`, `Configurable Product`, `Grouped Product`.
+There are three types of products that need to be configured before adding to the cart: `Bundle Product`, `Configurable Product`, and `Grouped Product`.
 
 1. In the grid, click **Configure** next to the product name.
 

--- a/src/sales/shopping-assisted-cart-manage.md
+++ b/src/sales/shopping-assisted-cart-manage.md
@@ -63,17 +63,16 @@ _Shopping Cart in in the customer account_
    ![]({% link images/images-ee/customer-account-manage-cart-update-cart.png %}){: .zoom}
    _Cart Updated_
 
-### Add a configurable product
+### Add a product with configuration
+
+There are 4 types of products that need to be configured before adding to the cart: `Bundle Product`, `Configurable Product`, `Grouped Product`.
 
 1. In the grid, click **Configure** next to the product name.
 
    ![]({% link images/images-ee/customer-account-manage-cart-order-configurable-product.png %}){: .zoom}
    _Configure_
 
-1. In the _Associated Products_ dialog, choose each product option to describe the item to be ordered, enter the **Quantity**, and click <span class="btn">OK<span/>.
-
-   ![]({% link images/images-ee/customer-account-manage-cart-order-configurable-product-associated.png %}){: .zoom}
-   _Choose product options_
+1. In the _Associated Products_ dialog, choose each product option to describe the item to be ordered, enter the **Quantity**, and click <span class="btn">OK</span>.
 
    The product is selected with a checkmark and the quantity ordered appears in the grid.
 
@@ -154,7 +153,7 @@ Items can be transferred to the cart from a customer wish list, as well as recen
 
 ## Create the order
 
-1. Click <span class="btn">Create Order<span/>.
+1. Click <span class="btn">Create Order</span>.
 
    The _Create New Order_ page shows the items in the cart, followed by the shipping and payment information.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request describes how to add a product with configuration for the Managing a Shopping Cart page. Removes the image for the Configurable product, because you can add 4 types of products with configurations to the cart.

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/sales/shopping-assisted-cart-manage.html?itm_source=merchdocs&itm_medium=quick_search&itm_campaign=federated_search&itm_term=manage%20shoping