### PR TITLE
2.3.x - Update installation.md 

### DIFF
--- a/src/magento/installation.md
+++ b/src/magento/installation.md
@@ -3,7 +3,7 @@ title: Installation
 group: getting-started
 ---
 
-To download and install the latest release of Magento 2.4.x on your server, see the [Installation][1]{:target="_blank"} and [Configuration][2]{:target="_blank"} in our developer documentation. The Magento installation can be deployed to run in either production or developer mode. Some tools and configuration settings are designed specifically for developers and can be accessed only while the store is running in developer mode. To learn more, see [Magento Modes]({% link magento/installation-modes.md %}).
+To download and install the latest release of Magento 2.3.x on your server, see the [Installation][1]{:target="_blank"} and [Configuration][2]{:target="_blank"} in our developer documentation. The Magento installation can be deployed to run in either production or developer mode. Some tools and configuration settings are designed specifically for developers and can be accessed only while the store is running in developer mode. To learn more, see [Magento Modes]({% link magento/installation-modes.md %}).
 
 The _Magento Installation Guide_ provides multiple options including download zip file, Composer, and cloned code repository. We recommend reviewing the following information:
 


### PR DESCRIPTION
Documentation only: text was saying Magento 2.4.x instead of Magento 2.3.x

## Purpose of this pull request

Fix doc. It was strange saying Magento 2.4.x when this page (and all the links) are about Magento 2.3.x

This pull request (PR) ...

## Magento release version

- [X] 2.3.x

## Product editions

Is this update specific to a product edition?

- [X] Magento Open Source only

## Additional information

