### PR TITLE
Update the list of the Actions Control grid page

### DIFF
--- a/src/stores/admin-actions-control.md
+++ b/src/stores/admin-actions-control.md
@@ -77,11 +77,14 @@ The checkbox in the first column of the list identifies each record that is a ta
 
 |List|Actions|
 |--- |--- |
-|All Customers|Delete<br/>Set Active<br/>Subscribe to Newsletter<br/>Unsubscribe from Newsletter<br/>Assign a Customer Group<br/>Edit|
+|All Customers|Delete<br/>Set Active<br/>Set Inactive<br/>Subscribe to Newsletter<br/>Unsubscribe from Newsletter<br/>Assign a Customer Group<br/>Edit|
+|Customer Groups|Delete|
 |<span class="b2b-only">Companies</span>|Set Active<br/>Block<br/>Delete<br/>Edit<br/>Convert Credit|
 
 ### Marketing
 
+|*Private Sales*|||
+||Invitations|Discard Selected<br/>Send Selected|
 |*Communications*|||
 ||Newsletter Subscribers|Unsubscribe<br/>Delete|
 |*SEO & Search*|||
@@ -97,6 +100,8 @@ The checkbox in the first column of the list identifies each record that is a ta
 ||Blocks|Delete<br/>Edit|
 ||Dynamic Blocks|Delete|
 ||Widgets|Delete|
+|*Design*|||
+||Themes|View|
 |**Reports**|||
 |*Customers*|||
 ||Segments|View Combined Report|


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the list of the Actions Control grid page.

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/stores/admin-actions-control.html?itm_source=merchdocs&itm_medium=search_page&itm_campaign=federated_search&itm_term=User%20Content