### PR TITLE
Add field descriptions to the content block pages

### DIFF
--- a/src/cms/page-hierarchy-configure.md
+++ b/src/cms/page-hierarchy-configure.md
@@ -15,3 +15,9 @@ _CMS Page Hierarchy_
 1. Expand ![Expansion selector]({% link images/images/btn-expand.png %}) **CMS Page Hierarchy**  and make any changes that are necessary.
 
 1. When complete, click <span class="btn">Save Config</span>.
+
+|Field|Description|
+|--- |--- |
+|Enable Hierarchy Functionality|Activates the use of page hierarchy for your content pages. Options: Yes / No|
+|Enable Hierarchy Metadata|Gives you the ability to associate meta data with pages in the hierarchy. Options: Yes / No|
+|Default Layout for Hierarchy Menu|Determines the default menu style. Options: Content / Left Column / Right Column|

--- a/src/design/layout-update-place-block.md
+++ b/src/design/layout-update-place-block.md
@@ -44,12 +44,6 @@ The following steps show how to use a layout update to place a block on a page. 
 
 1. Select the layout update that you want to apply to the page.
 
-|Field|Description|
-|--- |--- |
-|Layout|**Empty** - Use to define your own page layout. (Requires an understanding of XML.) <br/>**1 column** - Applies a one-column layout to the category page. <br/>**2 columns with left bar** - Applies a two-column layout with a left sidebar to the category page. <br/>**2 columns with right bar** - Applies a two-column layout with a right sidebar to the category page. <br/>**3 columns** - Applies a three-column layout to the category page.<br/><span class="ee-only">**Page -- Full Width**</span> - (Requires [Page Builder]({% link cms/page-builder.md %})) Applies the full-width layout for CMS pages to the category page. <br/><span class="ee-only">**Category -- Full Width**</span> - (Requires Page Builder) Applies the full-width layout for category pages to the category page. <br/><span class="ee-only">**Product -- Full Width**</span> - (Requires Page Builder) Applies the full-width layout for product pages to the category page.|
-|Custom Layout Update|Lists the available custom layout update files on the server. Choose the custom layout update that you want to apply to the category.|
-|New Theme|Applies a custom theme that determines the visual presentation of your store. Default options: Magento Blank, Magento Luma.|
-
 ## Step 4: Save and refresh cache
 
 1. When complete, click <span class="btn">Save & Close</span>.

--- a/src/design/layout-update-place-block.md
+++ b/src/design/layout-update-place-block.md
@@ -44,6 +44,12 @@ The following steps show how to use a layout update to place a block on a page. 
 
 1. Select the layout update that you want to apply to the page.
 
+|Field|Description|
+|--- |--- |
+|Layout|**Empty** - Use to define your own page layout. (Requires an understanding of XML.) <br/>**1 column** - Applies a one-column layout to the category page. <br/>**2 columns with left bar** - Applies a two-column layout with a left sidebar to the category page. <br/>**2 columns with right bar** - Applies a two-column layout with a right sidebar to the category page. <br/>**3 columns** - Applies a three-column layout to the category page.<br/><span class="ee-only">**Page -- Full Width**</span> - (Requires [Page Builder]({% link cms/page-builder.md %})) Applies the full-width layout for CMS pages to the category page. <br/><span class="ee-only">**Category -- Full Width**</span> - (Requires Page Builder) Applies the full-width layout for category pages to the category page. <br/><span class="ee-only">**Product -- Full Width**</span> - (Requires Page Builder) Applies the full-width layout for product pages to the category page.|
+|Custom Layout Update|Lists the available custom layout update files on the server. Choose the custom layout update that you want to apply to the category.|
+|New Theme|Applies a custom theme that determines the visual presentation of your store. Default options: Magento Blank, Magento Luma.|
+
 ## Step 4: Save and refresh cache
 
 1. When complete, click <span class="btn">Save & Close</span>.


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds field descriptions to the content block pages

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [ ] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/design/layout-update-place-block.html
https://docs.magento.com/user-guide/cms/page-hierarchy-configure.html