### PR TITLE
Edit invalid link on the About This Release page

### DIFF
--- a/src/magento/about-this-release.md
+++ b/src/magento/about-this-release.md
@@ -67,4 +67,4 @@ Magento 2.0.18 was the final 2.0.x release. After March 2018, Magento 2.0.x stop
 [18]: https://docs.magento.com/m2/pdf/ee/Magento-Commerce-2.3-User-Guide.pdf
 [19]: https://docs.magento.com/m2/pdf/b2b/Magento-for-B2B-Commerce-2.3-User-Guide.pdf
 [20]: https://docs.magento.com/m2/pdf/ce/Magento-Open-Source-2.3-User-Guide.pdf
-[21]: https://https://docs.magento.com/user-guide/v2.3/
+[21]: https://docs.magento.com/user-guide/v2.3/


### PR DESCRIPTION
## Purpose of this pull request

This pull request edits invalid link on the About This Release page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/magento/about-this-release.html