### PR TITLE
Remove b2b label from customer page images

### DIFF
--- a/src/customers/customers-all.md
+++ b/src/customers/customers-all.md
@@ -5,7 +5,7 @@ title: All Customers
 The Customers grid lists all customers who have registered for an account with your store or were added by the administrator. Use the standard [grid controls]({% link stores/admin-grid-controls.md %}) to filter the list and adjust the [column layout]({% link stores/admin-grid-layout.md %}). To learn more, see [Managing Customer Accounts]({% link customers/customer-account-manage.md %}).
 
 ![]({% link images/images-b2b/customers-all-grid.png %}){: .zoom}
-_All Customers_{:.b2b-only}
+_All Customers_
 
 ## View customer information
 

--- a/src/customers/customers-menu.md
+++ b/src/customers/customers-menu.md
@@ -5,7 +5,7 @@ title: Customers Menu
 The Customers menu provides access to customer account management tools, and gives you the ability to see who is currently online in your store.
 
 ![]({% link images/images-b2b/admin-menu-customers-b2b.png %}){: .zoom}
-_Customers Menu_{:.b2b-only}
+_Customers Menu_
 
 ## Display the Customers menu
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes b2b label from customer page images

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [ ] Magento Open Source only
- [ ] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [ ] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/customers/customers-menu.html
https://docs.magento.com/user-guide/customers/customers-all.html