### PR TITLE
Remove b2b and ee labels from the Catalog pages

### DIFF
--- a/src/catalog/catalog-menu.md
+++ b/src/catalog/catalog-menu.md
@@ -5,7 +5,7 @@ title: Catalog Menu
 The Catalog Menu provides easy access to product creation, category, and inventory management tools, as well as shared catalogs for custom pricing in B2B stores.
 
 ![]({% link images/images-b2b/admin-menu-catalog.png %}){: .zoom}
-_Catalog Menu_{:.b2b-only}
+_Catalog Menu_
 
 On the _Admin_ sidebar, click **Catalog**.
 

--- a/src/catalog/product-workspace.md
+++ b/src/catalog/product-workspace.md
@@ -5,7 +5,7 @@ title: Product Workspace
 The product workspace is basically the same for all product types, although the selection of fields changes depending on the attribute set that is used. The product attributes are at the top of the form, followed by expandable sections of product information. When a new product is saved for the first time, the Store View chooser appears at the upper-left of the form.
 
 ![]({% link images/images-ee/product-workspace-ee.png %}){: .zoom}
-_Product Workspace_{:.ee-only}
+_Product Workspace_
 
 ## Enable Product setting
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes b2b and ee labels from the Catalog pages

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/catalog/catalog-menu.html
https://docs.magento.com/user-guide/catalog/product-workspace.html