### PR TITLE
Add the Store Url Options block to the XML Sitemap page

### DIFF
--- a/src/configuration/catalog/xml-sitemap.md
+++ b/src/configuration/catalog/xml-sitemap.md
@@ -34,6 +34,16 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Cata
 |Frequency|Store View|Determines how often sitemap CMS pages are updated. Options: Always / Hourly / Daily / Weekly / Monthly / Yearly / Never|
 |Priority|Store View|A value between 0.0 and 1.0 that determines the priority of CMS page sitemap updates in relation to other content. Zero has the lowest priority.|
 
+## Store Url Options
+
+![]({% link images/images/store-url-options.png %}){: .zoom}
+_Store Url Options_
+
+|Field|[Scope]({% link configuration/scope.md %})|Description|
+|--- |--- |--- |
+|Frequency|Store View|Determines how often store url are updated. Options: Always / Hourly / Daily / Weekly / Monthly / Yearly / Never|
+|Priority|Store View|A value between 0.0 and 1.0 that determines the priority of store url updates in relation to other content. Zero has the lowest priority.|
+
 ## Generation Settings
 
 ![]({% link images/images/config-catalog-xml-sitemap-generation-settings.png %}){: .zoom}

--- a/src/configuration/catalog/xml-sitemap.md
+++ b/src/configuration/catalog/xml-sitemap.md
@@ -41,8 +41,8 @@ _Store Url Options_
 
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |
-|Frequency|Store View|Determines how often store url are updated. Options: Always / Hourly / Daily / Weekly / Monthly / Yearly / Never|
-|Priority|Store View|A value between 0.0 and 1.0 that determines the priority of store url updates in relation to other content. Zero has the lowest priority.|
+|Frequency|Store View|Determines how often store URLs are updated. Options: Always / Hourly / Daily / Weekly / Monthly / Yearly / Never|
+|Priority|Store View|A value between 0.0 and 1.0 that determines the priority of store URL updates in relation to other content. Zero (`0.0`) has the lowest priority.|
 
 ## Generation Settings
 

--- a/src/configuration/catalog/xml-sitemap.md
+++ b/src/configuration/catalog/xml-sitemap.md
@@ -36,9 +36,6 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Cata
 
 ## Store Url Options
 
-![]({% link images/images/store-url-options.png %}){: .zoom}
-_Store Url Options_
-
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |
 |Frequency|Store View|Determines how often store URLs are updated. Options: Always / Hourly / Daily / Weekly / Monthly / Yearly / Never|


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the Store Url Options block to the XML Sitemap page

## Magento release version

- [x] 2.4.x

   Specify a patch release number, if applicable:

- [ ] 2.3.x

   Specify a patch release number, if applicable:

## Product editions

Is this update specific to a product edition?

- [x] Magento Open Source only
- [x] Magento Commerce only

Is this update specific to an installed feature extension

- [x] B2B extension
- [x] Other feature set, please specify:

## Affected documentation pages

https://docs.magento.com/user-guide/configuration/catalog/xml-sitemap.html

whatsnew
Updated [XML Sitemap](https://docs.magento.com/user-guide/configuration/catalog/xml-sitemap.html) configuration reference topic to add section for _Store Url Options_.