### PR TITLE
Fix for links displaying at "My Account" page

### DIFF
--- a/src/customers/account-dashboard-my-account.md
+++ b/src/customers/account-dashboard-my-account.md
@@ -6,10 +6,10 @@ The My Account section of the customer dashboard gives customers an overview of 
 
 The My Account page consist of following sections:
 
-- [Account Information] ({% link customers/account-dashboard-account-information.md %})
-- [Address Book] ({% link customers/account-dashboard-address-book.md %})
-- [My Recent Reviews] ({% link customers/account-dashboard-my-product-reviews.md %})
-- [Recent Orders] ({% link customers/account-dashboard-my-orders.md %})
+- [Account Information]({% link customers/account-dashboard-account-information.md %})
+- [Address Book]({% link customers/account-dashboard-address-book.md %})
+- [My Recent Reviews]({% link customers/account-dashboard-my-product-reviews.md %})
+- [Recent Orders]({% link customers/account-dashboard-my-orders.md %})
 
 ![]({% link images/images-ee/customer-account-dashboard-my-account.png %}){: .zoom}
 _My Account_{:.ee-only}


### PR DESCRIPTION
This PR provides a six for links displaying at "My Account" page

**Before:**
<img width="1775" alt="Screenshot 2021-07-07 at 10 05 58" src="https://user-images.githubusercontent.com/40993770/124716893-416a8180-df0d-11eb-93ea-a91d4bb0bd62.png">

**After**
<img width="1775" alt="Screenshot 2021-07-07 at 10 06 37" src="https://user-images.githubusercontent.com/40993770/124716920-4a5b5300-df0d-11eb-91a6-584526f49e8a.png">

**Affected Pages:**
https://docs.magento.com/user-guide/customers/account-dashboard-my-account.html