### PR TITLE
Fix for camera icon displaying at Media Image page

### DIFF
--- a/src/cms/page-builder-media-image.md
+++ b/src/cms/page-builder-media-image.md
@@ -52,7 +52,7 @@ _Image toolbox_
 
       - Locate and choose the image to add it to the gallery and target container.
 
-      As an alternative, you can also drag an image file from your system and drop it on the Camera !Camera icon]({{site.baseurl}}/images/images-ee/icon-pb-camera.png){: width="25px"} icon.
+      As an alternative, you can also drag an image file from your system and drop it on the _Camera_ (![Camera Icon]({% link /images/images-ee/icon-pb-camera.png %}){: width="25px"}) icon.
 
    - **Select an existing asset**: Use this method to select an existing image asset from the media storage/gallery.
 


### PR DESCRIPTION
This PR provides a fix for displaying of camera icon at Media Image page

**Before**
<img width="1059" alt="Screenshot 2021-07-07 at 10 49 53" src="https://user-images.githubusercontent.com/40993770/124720978-5f39e580-df11-11eb-8e8d-78d485a487b0.png">

**After**
<img width="1059" alt="Screenshot 2021-07-07 at 10 49 33" src="https://user-images.githubusercontent.com/40993770/124721008-65c85d00-df11-11eb-853c-4809039fdbdd.png">

**Affected page:**
https://docs.magento.com/user-guide/cms/page-builder-media-image.html