### PR TITLE
Remove "Add Block Names to Hints" and add "Add Block Class Type to hints" where ever required in the docs

### DIFF
--- a/src/configuration/advanced/developer.md
+++ b/src/configuration/advanced/developer.md
@@ -44,7 +44,7 @@ Available in [Developer Mode]({% link magento/installation-modes.md %}) only.
 |--- |--- |--- |
 |Enable Template Path Hints for Storefront|Store View|Adds notation to storefront that indicates the path to each template that is used on the page. Options: Yes / No|
 |Enable Template Path Hints for Admin|Global|Adds notation to the Admin that indicates the path to each template that is used on the page. Options: Yes / No|
-|Add Block Names to Hints|Store View|Includes the names of blocks in the template path hints. Options: Yes / No|
+|Add Block Class Type to Hints|Store View|Includes the names of blocks in the template path hints. Options: Yes / No|
 
 ## Translate Inline
 

--- a/src/system/template-path-hints.md
+++ b/src/system/template-path-hints.md
@@ -36,7 +36,7 @@ Before using template path hints, add your IP address to the [allow list]({% li
 
     - To activate template path hints for the Admin, set **Enabled Template Path Hints for Admin** to `Yes`.
 
-    - To include the names of blocks, set **Add Block Names to Hints** to `Yes`.
+    - To include the names of blocks, set **Add Block Class Type to Hints** to `Yes`.
 
 1. When complete, click <span class="btn">Save Config</span>.
 


### PR DESCRIPTION

## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) fixes https://github.com/magento/merchdocs/issues/1381

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/configuration/advanced/developer.html
- https://docs.magento.com/user-guide/system/template-path-hints.html

