### PR TITLE
Fix broken 'Security' and 'Advanced' items on the Configuration Reference page

### DIFF
--- a/src/stores/configuration.md
+++ b/src/stores/configuration.md
@@ -11,7 +11,7 @@ sections:
     url: /configuration/catalog.html
 
   - title: Security
-    content: Security settings configures store security, Two-factor authentication, and the <a href="https://www.google.com/recaptcha/about/">Google reCAPTCHA</a> feature.
+    content: Security settings configures store security, Two-factor authentication, and the Google reCAPTCHA feature.
     url: /configuration/security.html
 
   - title: Customers
@@ -35,7 +35,7 @@ sections:
     url: /configuration/services.html
 
   - title: Advanced
-    content: Determines default Admin settings, various system configuration settings, advanced module controls, and developer tools (if the store is running in <a href="https://docs.magento.com/user-guide/magento/installation-modes.html">developer mode</a>).
+    content: Determines default Admin settings, various system configuration settings, advanced module controls, and developer tools (if the store is running in developer mode).
     url: /configuration/advanced.html
 
 ---


### PR DESCRIPTION

## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) fixes broken 'Security' and 'Advanced' items on the Configuration Reference page
![image](https://user-images.githubusercontent.com/78729171/125983359-6b14dc5b-a4c8-4648-9cd2-8b7d58a02e97.png)
![image](https://user-images.githubusercontent.com/78729171/125983405-dc9760d8-2dae-44ce-8742-74a55b7063e8.png)

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/stores/configuration.html
