### PR TITLE
MC-42708: Scheduled Export does not triggered by cron

### DIFF
--- a/src/system/data-schedule-export.md
+++ b/src/system/data-schedule-export.md
@@ -95,6 +95,9 @@ After each export, the export file is placed in the user-defined location, and a
 
     The new scheduled export job is added to the list on the _Scheduled Import/Export_ page. From this page it can be run immediately, for testing, and edited.
 
+{:.bs-callout-info}
+Scheduled export makes changes to Magento system configuration. After saving, make sure you follow the cache invalidation notice that will appear on top of the Magento admin page and flush the cache in order to apply the new or updated schedule.
+
 ## Field Descriptions
 
 ### Export Settings

--- a/src/system/data-schedule-export.md
+++ b/src/system/data-schedule-export.md
@@ -96,7 +96,7 @@ After each export, the export file is placed in the user-defined location, and a
     The new scheduled export job is added to the list on the _Scheduled Import/Export_ page. From this page it can be run immediately, for testing, and edited.
 
 {:.bs-callout-info}
-Scheduled export makes changes to Magento system configuration. After saving, make sure you follow the cache invalidation notice that will appear on top of the Magento admin page and flush the cache in order to apply the new or updated schedule.
+Scheduled export makes changes to the system configuration. After saving, make sure you address the cache invalidation notice that appears at the top of the Admin page and flush the cache in order to apply the new or updated schedule.
 
 ## Field Descriptions
 

--- a/src/system/data-schedule-import.md
+++ b/src/system/data-schedule-import.md
@@ -102,6 +102,9 @@ After each scheduled import job, a reindex operation is performed automatically.
 
     The new scheduled import job is added to the list on the _Scheduled Import/Export_ page. From this page it can be run immediately for testing and edited. The import file is validated before the execution of each import job.
 
+{:.bs-callout-info}
+Scheduled import makes changes to Magento system configuration. After saving, make sure you follow the cache invalidation notice that will appear on top of the Magento admin page and flush the cache in order to apply the new or updated schedule.
+
 ## Field Descriptions
 
 ### Import Settings

--- a/src/system/data-schedule-import.md
+++ b/src/system/data-schedule-import.md
@@ -103,7 +103,7 @@ After each scheduled import job, a reindex operation is performed automatically.
     The new scheduled import job is added to the list on the _Scheduled Import/Export_ page. From this page it can be run immediately for testing and edited. The import file is validated before the execution of each import job.
 
 {:.bs-callout-info}
-Scheduled import makes changes to Magento system configuration. After saving, make sure you follow the cache invalidation notice that will appear on top of the Magento admin page and flush the cache in order to apply the new or updated schedule.
+Scheduled import makes changes to the system configuration. After saving, make sure you address the cache invalidation notice that appears at the top of the Admin page and flush the cache in order to apply the new or updated schedule.
 
 ## Field Descriptions
 

--- a/src/system/data-scheduled-import-export.md
+++ b/src/system/data-scheduled-import-export.md
@@ -20,7 +20,7 @@ Scheduled imports and exports can be run on a daily, weekly or monthly basis. Th
 1. When the record is saved, the job appears in the _Scheduled Import/Export_ grid.
 
    {:.bs-callout-info}
-   Scheduled import/export makes changes to Magento system configuration. After saving, make sure you follow the cache invalidation notice that will appear on top of the Magento admin page and flush the cache in order to apply the new or updated schedule.
+   Scheduled import/export makes changes to the system configuration. After saving, make sure you address the cache invalidation notice that appears at the top of the Admin page and flush the cache in order to apply the new or updated schedule.
 
 1. After each scheduled job, a copy of the file is placed in the `var/log/import_export` directory on the Magento local server.
 

--- a/src/system/data-scheduled-import-export.md
+++ b/src/system/data-scheduled-import-export.md
@@ -19,6 +19,9 @@ Scheduled imports and exports can be run on a daily, weekly or monthly basis. Th
 
 1. When the record is saved, the job appears in the _Scheduled Import/Export_ grid.
 
+   {:.bs-callout-info}
+   Scheduled import/export makes changes to Magento system configuration. After saving, make sure you follow the cache invalidation notice that will appear on top of the Magento admin page and flush the cache in order to apply the new or updated schedule.
+
 1. After each scheduled job, a copy of the file is placed in the `var/log/import_export` directory on the Magento local server.
 
     The details of each operation are not written to the log. If an error occurs, notification is sent of the failed import/export job, with a description of the error.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add a callout stressing that after saving a scheduled import or export, there is a cache invalidation banner appearing at the top of the admin area. If the instructions from the banner will not be followed, the scheduled update won't take effect until the cache is flushed.

## Magento release version

 - 2.3
 - 2.4
## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- This update is specific to Adobe Commerce only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- EE

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/system/data-schedule-export.html
- https://docs.magento.com/user-guide/system/data-schedule-import.html
- https://docs.magento.com/user-guide/system/data-scheduled-import-export.html

