### PR TITLE
Added the link to Adobe Acrobate Reader on "Creating an Invoice" page

### DIFF
--- a/src/sales/invoice-create.md
+++ b/src/sales/invoice-create.md
@@ -73,3 +73,5 @@ _Invoices_
 
     ![]({% link images/images/invoice-full.png %}){: .zoom}
     _Completed Invoice_
+
+[1]: http://www.adobe.com/products/reader.html "Get Adobe Reader"


### PR DESCRIPTION
## Purpose of this pull request

Added the reference for Adobe Reader for correct displaying of Adobe Acrobat Reader link on  "Creating an Invoice" page

Before:
<img width="1285" alt="Screenshot 2021-08-06 at 14 52 49" src="https://user-images.githubusercontent.com/40993770/128507656-829c52c7-7352-4621-aa54-fd6a3f094f2f.png">

After:
<img width="1285" alt="Screenshot 2021-08-06 at 14 52 28" src="https://user-images.githubusercontent.com/40993770/128507682-afe7546b-cb36-492f-852b-96bb44b822bd.png">

Affected page:
https://docs.magento.com/user-guide/sales/invoice-create.html