### PR TITLE
Added the point about deleting permission rules for categories

### DIFF
--- a/src/catalog/catalog-shared-category-permissions-update.md
+++ b/src/catalog/catalog-shared-category-permissions-update.md
@@ -26,5 +26,6 @@ title: Updating Category Permissions
       _Category Permissions Rule_
 
     - To create a new permissions rule for another customer group, click <span class="btn">New Permissions</span> and repeat the process.
+    - To delete permission rule, click the ![]({% link images/images/btn-trashcan2.png %}) icon.
 
 1. When complete, click <span class="btn">Save</span>.

--- a/src/catalog/catalog-shared-category-permissions-update.md
+++ b/src/catalog/catalog-shared-category-permissions-update.md
@@ -26,6 +26,6 @@ title: Updating Category Permissions
       _Category Permissions Rule_
 
     - To create a new permissions rule for another customer group, click <span class="btn">New Permissions</span> and repeat the process.
-    - To delete permission rule, click the ![]({% link images/images/btn-trashcan2.png %}) icon.
+    - To delete a permission rule, click the ![Trash can]({% link images/images/btn-trashcan2.png %}) icon.
 
 1. When complete, click <span class="btn">Save</span>.


### PR DESCRIPTION
## Purpose of this pull request

Added the point about deleting permission rules for categories


## Affected documentation pages

https://docs.magento.com/user-guide/catalog/catalog-shared-category-permissions-update.html
