### PR TITLE
Transactions: Fixed the broken link, added additional info

### DIFF
--- a/src/sales/transactions.md
+++ b/src/sales/transactions.md
@@ -45,7 +45,7 @@ This section includes information regarding the transaction, and provides a link
 |Created At|Time and date the transaction was created.|
 
 ### Child transactions
-Child transactions are displayed in the grid after creating invoices for [orders]{% link sales/orders.md %}. This allows you to track transaction history, following a transaction hierarchy.
+Child transactions are displayed in the grid after creating invoices for [orders]({% link sales/orders.md %}). This allows you to track transaction history, following a transaction hierarchy.
 
 ### Transaction Details
 
@@ -73,3 +73,6 @@ This section includes the additional information for a given transaction. Inform
 - submitTimeUTC
 - taxExempt
 - transactionStatus
+
+{:.bs-callout-info}
+If the transaction details are not available or outdated click the **Fetch** button in menu bar to update them.

--- a/src/sales/transactions.md
+++ b/src/sales/transactions.md
@@ -75,4 +75,4 @@ This section includes the additional information for a given transaction. Inform
 - transactionStatus
 
 {:.bs-callout-info}
-If the transaction details are not available or outdated click the **Fetch** button in menu bar to update them.
+If the transaction details are not available or are outdated, click **Fetch** in the button bar to update them.


### PR DESCRIPTION
## Purpose of this pull request

Fixed the broken link to orders page
Added additional info about fetching transaction details

## Affected documentation pages

https://docs.magento.com/user-guide/sales/transactions.html
