### PR TITLE
The absence of spaces breaks the structure of the fields on the Product Export Attributes Reference page

### DIFF
--- a/src/system/data-attributes-product.md
+++ b/src/system/data-attributes-product.md
@@ -85,7 +85,7 @@ The installation used to export this data has the sample data installed, and has
 |upsell_position|Determines the position (sort order) of the SKUs that are listed as Up-sell Products in the upsell_skus column.|
 |additional_images|The  file names of any additional image to be associated with the product, preceded by a forward slash. For example: `/image.jpg`|
 |additional_image_labels|The labels associated with any additional images. For example: `Label 1`, `Label 2`|
-|custom_options|Specifies the properties and values assigned to each custom option. For example: <br/>`name=Color,type=drop_down,required=1,price= price_type=fixed,sku=,option_title=Black|name=Color,type=drop_down,required=1,price=,price_type=fixed,sku=,option_title=White`|
+|custom_options|Specifies the properties and values assigned to each custom option. For example: <br/>`name=Color, type=drop_down, required=1, price= price_type=fixed, sku=, option_title=Black|name=Color, type=drop_down, required=1, price=, price_type=fixed, sku=, option_title=White`|
 
 ### Service Data for Product Variations
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds the spaces to the Product Export Attributes Reference page

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

https://docs.magento.com/user-guide/system/data-attributes-product.html