### PR TITLE
Add the sort orders columns to the Creating Category Rules page

### DIFF
--- a/src/catalog/category-product-rules.md
+++ b/src/catalog/category-product-rules.md
@@ -73,6 +73,16 @@ Use caution when applying a category product rule, because any products that do 
     ![]({% link images/images-ee/automatic_sorting_field.png %}){: .zoom}
     _Automatic Sorting_
 
+    Sorting is based on current conditions:
+
+    |Stock quantity|Sort to top or bottom: `Move low stock to top` or `Move out of stock to bottom`|
+    |Special price|Sort to top or bottom: `Special price to top` or `Special price to bottom`|
+    |New Products|List newest products: `Newest products first`|
+    |Color|Sort alphabetically by color: `Sort by color`|
+    |Product Names|Sort by name in ascending or descending order: `Name A - Z` or `Name Z -A`|
+    |SKU|Sort by SKU in ascending or descending order: `SKU: Ascending` or `SKU: Descending`|
+    |Price|Sort by price in ascending or descending order: `Price: High to low` or `Price: Low to high`|
+
 1. When complete, click <span class="btn">Save Category</span>.
 
 {:.bs-callout-info}

--- a/src/catalog/category-product-rules.md
+++ b/src/catalog/category-product-rules.md
@@ -75,8 +75,8 @@ Use caution when applying a category product rule, because any products that do 
 
     Sorting is based on current conditions:
 
-    |Stock quantity|Sort to top or bottom: `Move low stock to top` or `Move out of stock to bottom`|
-    |Special price|Sort to top or bottom: `Special price to top` or `Special price to bottom`|
+    |Stock quantity|Sort based on stock, from top or bottom: `Move low stock to top` or `Move out of stock to bottom`|
+    |Special price|Sort based on price, from top or bottom: `Special price to top` or `Special price to bottom`|
     |New Products|List newest products: `Newest products first`|
     |Color|Sort alphabetically by color: `Sort by color`|
     |Product Names|Sort by name in ascending or descending order: `Name A - Z` or `Name Z -A`|


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request adds the sort orders columns to the Creating Category Rules page

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- yes

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

https://docs.magento.com/user-guide/catalog/category-product-rules.html