### PR TITLE
Describe how to reset orders columns and remove e-commerce label for the Order Action page 

### DIFF
--- a/src/sales/order-actions.md
+++ b/src/sales/order-actions.md
@@ -5,7 +5,7 @@ title: Order Actions
 To apply an action to specific orders, mark the checkbox in the first column of each order. To select or deselect all orders, use the control at the top of the column.
 
 ![]({% link images/images-ee/orders-action.png %}){: .zoom}
-_Order Actions_{:.ee-only}
+_Order Actions_
 
 ## Action Controls
 

--- a/src/sales/order-grid-layout.md
+++ b/src/sales/order-grid-layout.md
@@ -16,6 +16,17 @@ In the upper-right corner, click the **Columns** ( ![]({% link images/images/bt
 
 Make sure to scroll down to see all available columns.
 
+## To reset the column selection:
+
+1. Click the **Columns** ( ![]({% link images/images/btn-columns.png %} ){: .Inline}) control.
+
+1. To reset the grid columns, click the **Reset** button.
+
+    The grid layout displays now only default columns.
+
+    |Default grid columns|ID<br>Grand Total (Purchased)<br>Purchase Point<br>Purchase Date<br>Bill-to Name<br>Ship-to Name<br>Grand Total (Base)<br>Status<br>Action<br>Allocated sources<br>Braintree Transaction Source|
+    |Additional grid columns|Billing Address<br>Customer Email<br>Shipping and Handling<br>Payment Method<br>Refunded to Store Credit<br>Shipping Information<br>Subtotal<br>Company Name<br>Shipping Address<br>Customer Group<br>Customer Name<br>Total Refunded<br>Pickup Location Code|
+
 ## To move a column:
 
 1. Click and hold the header of the column.

--- a/src/sales/order-grid-layout.md
+++ b/src/sales/order-grid-layout.md
@@ -16,18 +16,18 @@ In the upper-right corner, click the **Columns** ( ![]({% link images/images/bt
 
 Make sure to scroll down to see all available columns.
 
-## To reset the column selection:
+## Reset the column selection
 
 1. Click the **Columns** ( ![]({% link images/images/btn-columns.png %} ){: .Inline}) control.
 
 1. To reset the grid columns, click the **Reset** button.
 
-    The grid layout displays now only default columns.
+    The grid layout changes to display only default columns.
 
     |Default grid columns|ID<br>Grand Total (Purchased)<br>Purchase Point<br>Purchase Date<br>Bill-to Name<br>Ship-to Name<br>Grand Total (Base)<br>Status<br>Action<br>Allocated sources<br>Braintree Transaction Source|
     |Additional grid columns|Billing Address<br>Customer Email<br>Shipping and Handling<br>Payment Method<br>Refunded to Store Credit<br>Shipping Information<br>Subtotal<br>Company Name<br>Shipping Address<br>Customer Group<br>Customer Name<br>Total Refunded<br>Pickup Location Code|
 
-## To move a column:
+## Move a column
 
 1. Click and hold the header of the column.
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request:
- Describes how to reset orders columns.
- Removes e-commerce label for the Order Action page.

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

https://docs.magento.com/user-guide/sales/order-grid-layout.html#to-move-a-column
https://docs.magento.com/user-guide/sales/order-actions.html