### PR TITLE
Add the missing field for the delivery methods

### DIFF
--- a/src/shipping/shipping-flat-rate.md
+++ b/src/shipping/shipping-flat-rate.md
@@ -57,8 +57,8 @@ Flat rate is a fixed, predefined charge that can be applied per item, or per shi
 
 1. Set **Show Method if Not Applicable**:
 
-   * `Yes` – Always shows the Free Shipping method, even when not applicable.
-   * `No` – Shows the Free Shipping method only when applicable.
+   - `Yes` – Always shows the Flat Rate method, even when not applicable.
+   - `No` – Shows the Flat Rate method only when applicable.
 
 1. For **Sort Order**, enter a number to determine the sequence in which Flat Rate Shipping appears when listed with other delivery methods during checkout.
 

--- a/src/shipping/shipping-flat-rate.md
+++ b/src/shipping/shipping-flat-rate.md
@@ -55,6 +55,11 @@ Flat rate is a fixed, predefined charge that can be applied per item, or per shi
    | All Allowed Countries | Customers from all [countries]({% link stores/country-options.md %}) specified in your store configuration can use this delivery method. |
    | Specific Countries | When you choose this option, the _Ship to Specific Countries_ list appears. Select each country in the list where this delivery method can be used. |
 
+1. Set **Show Method if Not Applicable**:
+
+   * `Yes` – Always shows the Free Shipping method, even when not applicable.
+   * `No` – Shows the Free Shipping method only when applicable.
+
 1. For **Sort Order**, enter a number to determine the sequence in which Flat Rate Shipping appears when listed with other delivery methods during checkout.
 
    `0` = first, `1` = second, `2` = third, and so on.

--- a/src/shipping/shipping-table-rate.md
+++ b/src/shipping/shipping-table-rate.md
@@ -72,6 +72,8 @@ The first step is to complete the default settings for table rates. You can comp
    | All Allowed Countries | Customers from all [countries]({% link stores/country-options.md %}) specified in your store configuration can use this delivery method. |
    | Specific Countries | When you choose this option, the _Ship to Specific Countries_ list appears. Select each country in the list where this delivery method can be used. |
 
+1. Set **Show Method if Not Applicable** to `Yes` if you want to show _Table Rates_ all time
+
 1. For **Sort Order**, enter a number to determine the sequence in which Table Rate Shipping appears when listed with other delivery methods during checkout.
 
    `0` = first, `1` = second, `2` = third, and so on.

--- a/src/shipping/shipping-table-rate.md
+++ b/src/shipping/shipping-table-rate.md
@@ -72,7 +72,7 @@ The first step is to complete the default settings for table rates. You can comp
    | All Allowed Countries | Customers from all [countries]({% link stores/country-options.md %}) specified in your store configuration can use this delivery method. |
    | Specific Countries | When you choose this option, the _Ship to Specific Countries_ list appears. Select each country in the list where this delivery method can be used. |
 
-1. Set **Show Method if Not Applicable** to `Yes` if you want to show _Table Rates_ all time
+1. Set **Show Method if Not Applicable** to `Yes` if you want to show Table Rates all time
 
 1. For **Sort Order**, enter a number to determine the sequence in which Table Rate Shipping appears when listed with other delivery methods during checkout.
 

--- a/src/shipping/shipping-table-rate.md
+++ b/src/shipping/shipping-table-rate.md
@@ -72,7 +72,7 @@ The first step is to complete the default settings for table rates. You can comp
    | All Allowed Countries | Customers from all [countries]({% link stores/country-options.md %}) specified in your store configuration can use this delivery method. |
    | Specific Countries | When you choose this option, the _Ship to Specific Countries_ list appears. Select each country in the list where this delivery method can be used. |
 
-1. Set **Show Method if Not Applicable** to `Yes` if you want to show Table Rates all time
+1. Set **Show Method if Not Applicable** to `Yes` if you want to show Table Rates all the time
 
 1. For **Sort Order**, enter a number to determine the sequence in which Table Rate Shipping appears when listed with other delivery methods during checkout.
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request adds the missing field for the delivery methods:
- Flat Rate
- Table Rates

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

https://docs.magento.com/user-guide/shipping/shipping-table-rate.html
https://docs.magento.com/user-guide/shipping/shipping-flat-rate.html