### PR TITLE
Fixed the save button's name on the Pagination Controls page

### DIFF
--- a/src/catalog/navigation-pagination.md
+++ b/src/catalog/navigation-pagination.md
@@ -40,4 +40,4 @@ _Pagination Controls_
 
 1. For **Anchor Text for Next**, enter the text that you want to appear for the Next link. Leave blank to use the default arrow.
 
-1. When complete, click <span class="btn">Save Config</span>.
+1. When complete, click <span class="btn">Save Configuration</span>.


### PR DESCRIPTION
## Purpose of this pull request

Fixed the save button's name on the Pagination Controls page.
The button calls "Save Configuration"

## Affected documentation pages

https://docs.magento.com/user-guide/catalog/navigation-pagination.html
