### PR TITLE
Add callout info about how many coupons can a Customer use in Magento 2

### DIFF
--- a/src/quick-tour/checkout-page.md
+++ b/src/quick-tour/checkout-page.md
@@ -16,7 +16,7 @@ Checkout consists of two steps:
    The second step of the checkout process is for the customer to choose the payment method and optionally apply a  discount code.
 
    {:.bs-callout-info}
-   Although _Magento 2_ allows configuring multiple coupon codes, a Customer can use **only one coupon code in the cart**. (See the [Coupon Codes]({% link marketing/price-rules-cart-coupon.md %}) for more information.)
+   Although Commerce allows configuring multiple coupon codes, a customer may use only one coupon code in the cart. (See the [Coupon Codes]({% link marketing/price-rules-cart-coupon.md %}) for more information.)
 
    ![Example storefront checkout page]({% link images/images/storefront-checkout-payment-full.png %}){: .zoom}
    _Checkout page (Review & Payments)_

--- a/src/quick-tour/checkout-page.md
+++ b/src/quick-tour/checkout-page.md
@@ -14,6 +14,9 @@ Checkout consists of two steps:
 1. Review and Payment Information
 
    The second step of the checkout process is for the customer to choose the payment method and optionally apply a  discount code.
+   
+   {:.bs-callout-info}
+   Although _Magento 2_ allows configuring multiple coupon codes, a Customer can use **only one coupon code in the cart**. (See the [Coupon Codes]({% link marketing/price-rules-cart-coupon.md %}) for more information.)
 
    ![Example storefront checkout page]({% link images/images/storefront-checkout-payment-full.png %}){: .zoom}
    _Checkout page (Review & Payments)_

--- a/src/quick-tour/checkout-page.md
+++ b/src/quick-tour/checkout-page.md
@@ -14,7 +14,7 @@ Checkout consists of two steps:
 1. Review and Payment Information
 
    The second step of the checkout process is for the customer to choose the payment method and optionally apply a  discount code.
-   
+
    {:.bs-callout-info}
    Although _Magento 2_ allows configuring multiple coupon codes, a Customer can use **only one coupon code in the cart**. (See the [Coupon Codes]({% link marketing/price-rules-cart-coupon.md %}) for more information.)
 

--- a/src/sales/checkout-process.md
+++ b/src/sales/checkout-process.md
@@ -60,6 +60,9 @@ _Checkout step 1: shipping_
 
 During the second step of the checkout process, the customer chooses the [payment method]({% link payment/payments.md %}), and applies any coupons with promotional codes to the purchase. All information can be reviewed, and edited if needed. If enabled, the customer must to agree to the terms and conditions of the sale before placing the order.
 
+{:.bs-callout-info}
+Although _Magento 2_ allows configuring multiple coupon codes, a Customer can use **only one coupon code in the cart**. (See the [Coupon Codes]({% link marketing/price-rules-cart-coupon.md %}) for more information.)
+
 ![]({% link images/images/storefront-checkout-step2-payment-review.png %}){: .zoom}
 _Review and payment page during checkout_
 

--- a/src/sales/checkout-process.md
+++ b/src/sales/checkout-process.md
@@ -61,7 +61,7 @@ _Checkout step 1: shipping_
 During the second step of the checkout process, the customer chooses the [payment method]({% link payment/payments.md %}), and applies any coupons with promotional codes to the purchase. All information can be reviewed, and edited if needed. If enabled, the customer must to agree to the terms and conditions of the sale before placing the order.
 
 {:.bs-callout-info}
-Although _Magento 2_ allows configuring multiple coupon codes, a Customer can use **only one coupon code in the cart**. (See the [Coupon Codes]({% link marketing/price-rules-cart-coupon.md %}) for more information.)
+Although Commerce allows configuring multiple coupon codes, a customer may use only one coupon code in the cart. (See the [Coupon Codes]({% link marketing/price-rules-cart-coupon.md %}) for more information.)
 
 ![]({% link images/images/storefront-checkout-step2-payment-review.png %}){: .zoom}
 _Review and payment page during checkout_


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) adds callout info about how many coupons can a Customer use in Magento 2

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/quick-tour/checkout-page.html
- https://docs.magento.com/user-guide/sales/checkout-process.html
