### PR TITLE
Add info about domain setting for the Magento stores of the Scope Quick Reference topic

### DIFF
--- a/src/stores/store-scope-reference.md
+++ b/src/stores/store-scope-reference.md
@@ -22,6 +22,7 @@ group: getting-started
 |Checkout|The [checkout process]({% link sales/checkout-process.md %}) takes place at the website level, although some display options can be configured for each store view. All stores associated with a website have the same [checkout configuration]({% link sales/checkout-options.md %}).|
 |Allowed countries|Allowed countries can be configured on the website level. The [allowed countries]({% link stores/country-options.md %}) settings are used in the checkout to limit where a customer can come from.|
 |**Store**||
+|Domain|In the case of multiple stores, each store can have the same domain, a subdomain, or have distinctly different domains. For more information, see [Adding Stores]({% link stores/stores-all-create-store.md %}).|
 |Root Category|Each store can have a separate set of products and main menu that is based on a “root” category and subcategories. Each catalog has a [root category]({% link catalog/category-root.md %}) that is assigned at the store level.|
 |**Store View**||
 |Subcategories|The [subcategories]({% link catalog/category-create.md %}) that make up the main menu (under the root) are assigned at the store view level.|

--- a/src/stores/store-scope-reference.md
+++ b/src/stores/store-scope-reference.md
@@ -22,7 +22,7 @@ group: getting-started
 |Checkout|The [checkout process]({% link sales/checkout-process.md %}) takes place at the website level, although some display options can be configured for each store view. All stores associated with a website have the same [checkout configuration]({% link sales/checkout-options.md %}).|
 |Allowed countries|Allowed countries can be configured on the website level. The [allowed countries]({% link stores/country-options.md %}) settings are used in the checkout to limit where a customer can come from.|
 |**Store**||
-|Domain|In the case of multiple stores, each store can have the same domain, a subdomain, or have distinctly different domains. For more information, see [Adding Stores]({% link stores/stores-all-create-store.md %}).|
+|Domain|In the case of multiple stores, each store can have the same domain, a subdomain, or distinctly different domains. For more information, see [Adding Stores]({% link stores/stores-all-create-store.md %}).|
 |Root Category|Each store can have a separate set of products and main menu that is based on a “root” category and subcategories. Each catalog has a [root category]({% link catalog/category-root.md %}) that is assigned at the store level.|
 |**Store View**||
 |Subcategories|The [subcategories]({% link catalog/category-create.md %}) that make up the main menu (under the root) are assigned at the store view level.|


### PR DESCRIPTION

## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) adds info about domain setting for the Magento stores of the Scope Quick Reference topic

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/stores/store-scope-reference.html


## Links to Magento source code or PRs

_OPTIONAL. If this pull request references a file in a Magento codebase repository or a code PR, add it here._

- https://docs.magento.com/user-guide/stores/stores-all-create-store.html
