### PR TITLE
ACP2E-228: [Documentation] Add notice that the cookie path can't contain any cookie parameters except path to folders

### DIFF
--- a/src/configuration/general/web.md
+++ b/src/configuration/general/web.md
@@ -93,8 +93,8 @@ _[Default Layouts]({% link design/page-layout.md %})_{:.ee-only}
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |
 |Cookie Lifetime|Store View|Determines how long a cookie can exist before it is automatically deleted; Default value is 3600 seconds (1 hour)|
-|Cookie Path|Store View|Specifies the folders on the server where Commerce cookies can be used. To make Commerce cookies available everywhere in the installation, set the Cookie Path to a single forward slash: `/`. It can't contain any other cookie parameters, except the cookie path.|
-|Cookie Domain|Store View|Determines if Commerce cookies are available to subdomains. For example, to support mysubdomain.domain.com, enter the name of your domain with a period at the beginning, like `.domain.com`. It can't contain any other cookie parameters, except the cookie domain.|
+|Cookie Path|Store View|Specifies the folders on the server where Commerce cookies can be used. To make Commerce cookies available everywhere in the installation, set the Cookie Path to a single forward slash: `/`. This value can contain only the cookie path, and **_cannot_** contain any other cookie parameters.|
+|Cookie Domain|Store View|Determines if Commerce cookies are available to subdomains. For example, to support mysubdomain.domain.com, enter the name of your domain with a period at the beginning, like `.domain.com`. This value can contain only the cookie domain, and **_cannot_** contain any other cookie parameters.|
 |Use HTTP Only|Store View|Determines if Commerce Cookies can be used only over an unsecure channel (http), or can also be used over an encrypted channel (https). Options: Yes / No|
 |Cookie Restriction Mode|Website|Determines if Cookie Restriction Mode is enabled. Options: Yes / No|
 

--- a/src/configuration/general/web.md
+++ b/src/configuration/general/web.md
@@ -93,8 +93,8 @@ _[Default Layouts]({% link design/page-layout.md %})_{:.ee-only}
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |
 |Cookie Lifetime|Store View|Determines how long a cookie can exist before it is automatically deleted; Default value is 3600 seconds (1 hour)|
-|Cookie Path|Store View|Specifies the folders on the server where Commerce cookies can be used. To make Commerce cookies available everywhere in the installation, set the Cookie Path to a single forward slash: `/`.|
-|Cookie Domain|Store View|Determines if Commerce cookies are available to subdomains. For example, to support mysubdomain.domain.com, enter the name of your domain with a period at the beginning, like `.domain.com`.|
+|Cookie Path|Store View|Specifies the folders on the server where Commerce cookies can be used. To make Commerce cookies available everywhere in the installation, set the Cookie Path to a single forward slash: `/`. It can't contain any other cookie parameters, except the cookie path.|
+|Cookie Domain|Store View|Determines if Commerce cookies are available to subdomains. For example, to support mysubdomain.domain.com, enter the name of your domain with a period at the beginning, like `.domain.com`. It can't contain any other cookie parameters, except the cookie domain.|
 |Use HTTP Only|Store View|Determines if Commerce Cookies can be used only over an unsecure channel (http), or can also be used over an encrypted channel (https). Options: Yes / No|
 |Cookie Restriction Mode|Website|Determines if Cookie Restriction Mode is enabled. Options: Yes / No|
 

--- a/src/stores/compliance-cookie-restriction-mode.md
+++ b/src/stores/compliance-cookie-restriction-mode.md
@@ -26,9 +26,9 @@ _Cookie Restriction Notice In Footer_
 
     - Enter the **Cookie Lifetime** in seconds.
 
-    - If you want to make cookies available to other folders, enter the **Cookie Path**. To make the cookies available anywhere in the site, enter a forward slash (`/`). It can't contain any other cookie parameters, except the cookie path.
+    - If you want to make cookies available to other folders, enter the **Cookie Path**. To make the cookies available anywhere in the site, enter a forward slash (`/`). This value can contain only the cookie path, and **_cannot_** contain any other cookie parameters.
 
-    - To make the cookies available to a subdomain, enter the subdomain name in the **Cookie Domain** field (`subdomain.yourdomain.com`). To make cookies available to all subdomains, enter the domain name preceded by a period (`.yourdomain.com`). It can't contain any other cookie parameters, except the cookie domain.
+    - To make the cookies available to a subdomain, enter the subdomain name in the **Cookie Domain** field (`subdomain.yourdomain.com`). To make cookies available to all subdomains, enter the domain name preceded by a period (`.yourdomain.com`). This value can contain only the cookie domain, and **_cannot_** contain any other cookie parameters.
 
     - To prevent scripting languages, such as JavaScript, from gaining access to cookies, make sure that **Use HTTP Only** is set to `Yes`.
 

--- a/src/stores/compliance-cookie-restriction-mode.md
+++ b/src/stores/compliance-cookie-restriction-mode.md
@@ -26,9 +26,9 @@ _Cookie Restriction Notice In Footer_
 
     - Enter the **Cookie Lifetime** in seconds.
 
-    - If you want to make cookies available to other folders, enter the **Cookie Path**. To make the cookies available anywhere in the site, enter a forward slash (`/`).
+    - If you want to make cookies available to other folders, enter the **Cookie Path**. To make the cookies available anywhere in the site, enter a forward slash (`/`). It can't contain any other cookie parameters, except the cookie path.
 
-    - To make the cookies available to a subdomain, enter the subdomain name in the **Cookie Domain** field (`subdomain.yourdomain.com`). To make cookies available to all subdomains, enter the domain name preceded by a period (`.yourdomain.com`).
+    - To make the cookies available to a subdomain, enter the subdomain name in the **Cookie Domain** field (`subdomain.yourdomain.com`). To make cookies available to all subdomains, enter the domain name preceded by a period (`.yourdomain.com`). It can't contain any other cookie parameters, except the cookie domain.
 
     - To prevent scripting languages, such as JavaScript, from gaining access to cookies, make sure that **Use HTTP Only** is set to `Yes`.
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

According to the investigation in the ACP2E-223, in Magento Admin it is implemented the validation that the Cookie Path field must contain only the path and no other cookie parameters.
But it is not reflected in the Magento documentation.
So it confuses some Merchants.
So it should be mentioned in the Magento 2.4.x User Guide to let them know that they cannot use any other cookie parameters except the path to folders on their server.

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

-Magento Open Source

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- ...

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/configuration/general/web.html
- https://docs.magento.com/user-guide/stores/compliance-cookie-restriction-mode.html