### PR TITLE
ACP2E-234: [Documentation] Add notice that configurable and grouped child products can be simple or virtual products without custom options

### DIFF
--- a/src/catalog/product-create-configurable.md
+++ b/src/catalog/product-create-configurable.md
@@ -342,6 +342,8 @@ If you have a different image for each variation you can set the configuration t
 
 - A configurable product allows the shopper to choose options from drop-down, multiple select, visual swatch and text swatch input types. Each option is a separate, simple product.
 
+- Configurable child products can be simple or virtual products **without custom options**.
+
 - The attributes that are used for product variations must have a global scope and the customer must be required to choose a value. The product variation attributes must be included in the attribute set that is used as a template for the configurable product.
 
 - The attribute set that is used as a template for a configurable product must include the attribute(s) that contain the values that are needed for each product variation.

--- a/src/catalog/product-create-grouped.md
+++ b/src/catalog/product-create-grouped.md
@@ -186,6 +186,8 @@ If you have a different image for each product in the group, you can set the con
 
 - A grouped product is essentially a collection of simple associated products.
 
+- Grouped child products can be simple or virtual products **without custom options**.
+
 - Each item purchased appears individually in the shopping cart, rather than as part of the group.
 
 - The thumbnail image in the shopping cart can be set to display the image from the grouped parent product or associated product.


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

According to the Product Owner confirmation in scope of ACP2E-216 defect investigation we should mention in the Magento User Guide that configurable and grouped child products can be simple or virtual products without custom options in the "Things to remember" section.
This information is already mentioned in the same "Things to remember" section for the Bundle Product page, but missed for Configurable and Grouped product pages accordingly.

Following text should be added on the Configurable Product and Grouped Product pages of User Guide into the "Things to remember" section.

https://docs.magento.com/user-guide/catalog/product-create-configurable.html
"Things to remember" section:
`- Configurable child products can be simple or virtual products **without custom options**.`

https://docs.magento.com/user-guide/catalog/product-create-grouped.html
"Things to remember" section:
`- Grouped child products can be simple or virtual products **without custom options**.`

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x
and
Magento 2.3.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

-Magento Open Source

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- ...

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

https://docs.magento.com/user-guide/catalog/product-create-configurable.html
https://docs.magento.com/user-guide/catalog/product-create-grouped.html