### PR TITLE
Fixed image displaying on the gift options page

### DIFF
--- a/src/catalog/product-gift-options.md
+++ b/src/catalog/product-gift-options.md
@@ -43,4 +43,5 @@ You can provide this feature to customers by enabling _gift message_ for your st
 
 With this configuration, customers can add a gift message to the cart page from storefront as shown in the following example:
 
-    ![]({% link images/images/gift-message.png%}){: .zoom}
+![]({% link images/images/gift-message.png %}){: .zoom}
+_Gift Message_


### PR DESCRIPTION
## Purpose of this pull request

Fixed image displaying on the gift options page

**BEFORE**
<img width="1228" alt="Screenshot 2021-10-12 at 12 47 41" src="https://user-images.githubusercontent.com/40993770/136933642-ec4c993f-f67c-4afb-9171-456cc20c8ee3.png">

**AFTER**
<img width="1228" alt="Screenshot 2021-10-12 at 12 47 33" src="https://user-images.githubusercontent.com/40993770/136933671-be6429c9-aa9a-4998-9a31-a645ec0e55cf.png">
This pull request (PR) ...

## Affected documentation pages

https://docs.magento.com/user-guide/catalog/product-gift-options.html