### PR TITLE
ACP2E-260: [Documentation] Add notice that coupon code related fields cannot be used in Cart Price Rule scheduled updates

### DIFF
--- a/src/marketing/price-rule-cart-scheduled-changes.md
+++ b/src/marketing/price-rule-cart-scheduled-changes.md
@@ -9,7 +9,7 @@ Keep in mind the following caveats:
 
 - If a campaign that includes a price rule is initially created without an end date, the campaign cannot later be edited to include an end date. It is recommended that you either add an end date when you create the campaign or create a duplicate version of the existing campaign and add the end date to the duplicate as needed.
 - When using a scheduled update to enable a cart price rule with an end date, be sure to set the rule as initially disabled. Rules that are already active will not respect the end date.
-- Coupon, Coupon Code, Uses per Coupon, Uses per Customer fields from the Rule Information tab and all fields from the Manage Coupon Codes tab are not available for the Schedule Update since coupons itself are disconnected from the rules.
+- Coupons are not specifically connected to cart price rules. A Scheduled Update does not provide access to the _Coupon_, _Coupon Code_, _Uses per Coupon_, and _Uses per Customer_ fields on the _Rule Information_ tab.  Additionally, all settings from the _Manage Coupon Codes_ tab are not available.
 
 If there are multiple price rules running in the same campaign, the Priority setting of the price rule determines which rule takes precedence. To learn more, see [Content Staging]({% link cms/content-staging.md -%}).
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

According to the Product Owner clarification in the scope of MC-42771 information should be added about following fields are not available for the Cart Price Rules scheduled updates:
- Coupon
- Coupon Code
- Uses per Coupon
- Uses per Customer
- Manage Coupon Codes tab fields

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

-Adobe Commerce only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- ...

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

-https://docs.magento.com/user-guide/marketing/price-rule-cart-scheduled-changes.html

whatsnew
Updated the [Scheduled Changes for Cart Price Rules](https://docs.magento.com/user-guide/marketing/price-rule-cart-scheduled-changes.html) topic to include information about the coupon-related fields that are not available for the Cart Price Rules scheduled updates.