### PR TITLE
ACP2E-265: [Documentation] Add note that invoices are not created automatically for Credit Card and other offline payment methods

### DIFF
--- a/src/sales/invoice-create.md
+++ b/src/sales/invoice-create.md
@@ -9,7 +9,7 @@ Normally, orders are invoiced and captured when the shipping process starts. If 
 When the state of new orders is set to `Processing`, the option to _Automatically Invoice All Items_ becomes available in the configuration. Some credit card payment methods complete the invoicing step as part of the process when the [payment action]({% link configuration/sales/payment-methods.md %}#payment-actions) is set to `Authorize and Capture`. In such a case, the Invoice button does not appear, and the order is ready to ship.
 
 {:.bs-callout-info}
-Invoices are not created automatically for orders placed by using `Gift Card`, `Store Credit`, `Reward Points` and other offline payment methods.
+Invoices are not created automatically for orders placed by using `Gift Card`, `Store Credit`, `Reward Points`, or other offline payment methods.
 
 You must generate an invoice for an order before you can print it. To view or print the PDF, first download and install a PDF reader such as [Adobe Acrobat Reader][1].
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

According to the Product Owner clarification in the scope of MC-42238 and  MC-42508 it should be added a notice that invoices are not created automatically for orders placed by using Gift Card, Store Credit, Reward Points and other offline payment methods.

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

-Both Adobe Commerce and Magento Open Source

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- ...

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

https://docs.magento.com/user-guide/sales/invoice-create.html

whatsnew
Updated the [Creating an Invoice](https://docs.magento.com/user-guide/sales/invoice-create.html) topic to clarify that invoices are not created automatically for orders placed by using Gift Card, Store Credit, Reward Points, or other offline payment methods.