### PR TITLE
ACP2E-273: [Documentation] Add note to use sRGB color profile during the product images upload

### DIFF
--- a/src/catalog/product-image-resizing.md
+++ b/src/catalog/product-image-resizing.md
@@ -5,9 +5,8 @@ title: Resizing Product Images
 When uploading product images, you may add larger images with varying sizes to provide detailed, high quality zooms on the _Product Details_ page. To ensure all images have a similar size and look, we provide an image upload resizing option to ensure all images match a specific pixel size. This option automatically resizes all product images using the configuration settings, which can help with performance of zoom, faster loading of images and keep a uniform look to your product images.
 
 {:.bs-callout-info}
-We recommend to upload all product images with `sRGB` color profile for the best compatibility.
-All other color profiles will be automatically converted to the `sRGB` color profile during the product images upload.
-This may cause to the color inconsistency in the uploaded images.
+For the best compatibility, it is recommended to upload all product images with the `sRGB` color profile.
+All other color profiles are automatically converted to the `sRGB` color profile during the product image upload, which could cause color inconsistency in the uploaded image.
 
 Setting a maximum pixel width and height resizes the image to the physical dimensions by pixel. Commerce resizes the image according to the higher amount of either width or height while keeping the proportions. Reducing the quality amount for JPG images reduces the file size.
 

--- a/src/catalog/product-image-upload.md
+++ b/src/catalog/product-image-upload.md
@@ -17,9 +17,8 @@ If you plan to upload large images for viewing on the _Product Details_ page, yo
 ### Upload an image
 
 {:.bs-callout-info}
-We recommend to upload all product images with `sRGB` color profile for the best compatibility.
-All other color profiles will be automatically converted to the `sRGB` color profile during the product images upload.
-This may cause to the color inconsistency in the uploaded images.
+For the best compatibility, it is recommended to upload all product images with the `sRGB` color profile.
+All other color profiles are automatically converted to the `sRGB` color profile during the product image upload, which could cause color inconsistency in the uploaded image.
 
 To upload an image, do one of the following:
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

According to the Product Owner recommendation in the scope of MC-42482 issue following callout should be added to let merchants know that sRGB color profile is recommended to be used during the product images upload:
```
We recommend to upload all product images with `sRGB` color profile for the best compatibility.
All other color profiles will be automatically converted to the `sRGB` color profile during the product images upload.
This may cause to the color inconsistency in the uploaded images.
```

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

Magento Open Source only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- ...

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

-https://docs.magento.com/user-guide/catalog/product-image-upload.html
-https://docs.magento.com/user-guide/catalog/product-image-resizing.html

Updated the [Resizing Product Images](https://docs.magento.com/user-guide/catalog/product-image-resizing.html) and [Uploading Product Images](https://docs.magento.com/user-guide/catalog/product-image-resizing.html) topics to advise about color profiles used for uploaded product images.