### PR TITLE
Add missing parameters to the Configuring Tax Classes page

### DIFF
--- a/src/tax/tax-class-configure.md
+++ b/src/tax/tax-class-configure.md
@@ -15,11 +15,20 @@ The tax class that is used for shipping, and the default tax classes for [produc
 
 1. Expand ![]({% link images/images/btn-expand.png %}) the **Tax Classes** section.
 
-1. Choose the tax class for each of the following:
+1. Set **Tax Class for Shipping**, **Tax Class for Gift Options** and **Default Tax Class for Product** to one of the following:
 
-    - **Set Tax Class for Shipping**
-    - **Tax Class for Gift Options**
-    - **Default Tax Class for Product**
-    - **Default Tax Class for Customer**
+    - None
+    - Taxable Goods
+    - Refund Adjustments
+    - Gift Options
+    - Order Gift Wrapping
+    - Item Gift Wrapping
+    - Printed Gift Card
+    - Reward Points
+    - VAT Reduced
+    - VAT Standard
+    - VAT Zero
+
+1. Set the **Default Tax Class for Customers**, `Retail Customer` is the default option provided by Magento.
 
 1. When complete, click <span class="btn">Save Config</span>.


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request adds missing parameters to the Configuring Tax Classes page

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

https://docs.magento.com/user-guide/tax/tax-class-configure.html