### PR TITLE
Yotpo user guide > Fixing typo

### DIFF
--- a/src/marketing/yotpo-settings.md
+++ b/src/marketing/yotpo-settings.md
@@ -6,7 +6,7 @@ When Yotpo is enabled, Commerce sets default values for your Widget and Sync set
 
 Access these basic Yotpo settings in the Admin at **Stores** > _Settings_ > **Configuration** when you choose **Yotpo** > **Reviews and Visual Marketing**. See [Reviews and Visual Marketing]({% link configuration/yotpo/reviews-visual-marketing.md %}).
 
-Additional Yotpo features and options are dependent on the Yotpo plan you choose. AAdobe Commerce and Magento Open Source support the Free, Growth, and Premium plans. See Yotpo [Plan Information](https://www.yotpo.com/pricing/) for plans and features.
+Additional Yotpo features and options are dependent on the Yotpo plan you choose. Adobe Commerce and Magento Open Source support the Free, Growth, and Premium plans. See Yotpo [Plan Information](https://www.yotpo.com/pricing/) for plans and features.
 
 See also [Yotpo documentation](https://support.yotpo.com/en/article/setting-up-yotpo-on-magento-v22-and-above) for information on mapping order statuses sent to Yotpo, sync settings, manually adding Yotpo's Reviews Widget to product pages, and manually placing Star Ratings on category pages.
 


### PR DESCRIPTION
I'm fixing the typo below in the page: https://docs.magento.com/user-guide/marketing/yotpo-settings.html

<img width="1252" alt="Screen Shot 2021-10-20 at 4 52 47 PM" src="https://user-images.githubusercontent.com/610598/138170476-b4997bc5-7c3a-4295-af38-aff5bbb7b407.png">

