### PR TITLE
Describe how to add CMS block to the Category page

### DIFF
--- a/src/catalog/categories-content-settings.md
+++ b/src/catalog/categories-content-settings.md
@@ -46,6 +46,25 @@ For more information, see [Using the Editor]({% link cms/editor.md %}).
 
    You can drag the lower-right corner to change the height of the text box.
 
+## How to display CMS block category page
+
+1. On the _Admin_ sidebar, go to **Catalog** > **Categories**
+
+1. In the category tree, select the category that you want to edit.
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the **Content** section.
+
+1. In the **Add the CMS block** field select a block you want to add.
+
+1. Expand ![]({% link images/images/btn-expand.png %}) the **Display Settings** section.
+
+1. Set the **Display Mode** to one of the following:
+
+   - Static block only
+   - Static block and products
+
+1. When complete, click <span class="btn">Save</span> and check the CMS block out on the storefront.
+
 ## Content settings reference
 
 |Setting|[Scope]({% link configuration/scope.md %})|Description|

--- a/src/catalog/categories-content-settings.md
+++ b/src/catalog/categories-content-settings.md
@@ -62,7 +62,7 @@ For more information, see [Using the Editor]({% link cms/editor.md %}).
 
    - `Static block only`
    - `Static block and products`
-   
+
 1. When complete, click <span class="btn">Save</span> and review the block display on the storefront (requires cache refresh).
 
 ## Content settings reference

--- a/src/catalog/categories-content-settings.md
+++ b/src/catalog/categories-content-settings.md
@@ -46,24 +46,24 @@ For more information, see [Using the Editor]({% link cms/editor.md %}).
 
    You can drag the lower-right corner to change the height of the text box.
 
-## How to display CMS block category page
+## Add a CMS block to the category page
 
-1. On the _Admin_ sidebar, go to **Catalog** > **Categories**
+1. On the _Admin_ sidebar, go to **Catalog** > **Categories**.
 
 1. In the category tree, select the category that you want to edit.
 
-1. Expand ![]({% link images/images/btn-expand.png %}) the **Content** section.
+1. Expand ![Expansion selector]({% link images/images/btn-expand.png %}) the **Content** section.
 
-1. In the **Add the CMS block** field select a block you want to add.
+1. For **Add the CMS block**, select a block you want to add.
 
-1. Expand ![]({% link images/images/btn-expand.png %}) the **Display Settings** section.
+1. Expand ![Expansion selector]({% link images/images/btn-expand.png %}) the **Display Settings** section.
 
 1. Set the **Display Mode** to one of the following:
 
-   - Static block only
-   - Static block and products
-
-1. When complete, click <span class="btn">Save</span> and check the CMS block out on the storefront.
+   - `Static block only`
+   - `Static block and products`
+   
+1. When complete, click <span class="btn">Save</span> and review the block display on the storefront (requires cache refresh).
 
 ## Content settings reference
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request describes how to add CMS block to the Category page

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

https://docs.magento.com/user-guide/catalog/categories-content-settings.html

whatsnew
Updated the [Category Content](https://docs.magento.com/user-guide/catalog/categories-content-settings.html) page to include the procedure for adding a CMS block to the _Content_ properties for a category.