### PR TITLE
Add correct Product Alert link to the Catalog Configuration list

### DIFF
--- a/src/configuration/catalog/catalog.md
+++ b/src/configuration/catalog/catalog.md
@@ -50,7 +50,7 @@ Stores > Settings > [Configuration]({% link stores/configuration.md %}) > [Cata
 ## Product Alerts
 
 ![]({% link images/images/config-catalog-catalog-product-alerts.png %}){: .zoom}
-[_Product Alerts_]({% link configuration/scope.md %})
+[_Product Alerts_]({% link catalog/inventory-product-alerts.md %})
 
 |Field|[Scope]({% link configuration/scope.md %})|Description|
 |--- |--- |--- |


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request adds correct Product Alert link to the Catalog Configuration list

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

https://docs.magento.com/user-guide/configuration/catalog/catalog.html