### PR TITLE
clarification on diff Recs source

### DIFF
--- a/src/marketing/recommendation-change-source.md
+++ b/src/marketing/recommendation-change-source.md
@@ -36,4 +36,4 @@ Before you begin, make sure that:
    Adobe Commerce will now fetch recommendations from that environment.
 
    {:.bs-callout-info}
-   Recommendations from another SaaS data space can be viewed on the non-production storefront, but not clicked.
+   While you can view recommendations fetched from another SaaS data space on the non-production storefront, you cannot click the recommendations.

--- a/src/marketing/recommendation-change-source.md
+++ b/src/marketing/recommendation-change-source.md
@@ -36,4 +36,4 @@ Before you begin, make sure that:
    Adobe Commerce will now fetch recommendations from that environment.
 
    {:.bs-callout-info}
-   Recommendations from another SaaS data space can be previewed by shoppers, but not clicked.
+   Recommendations from another SaaS data space can be viewed on the non-production storefront, but not clicked.


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) clarifies that shoppers cannot preview Recommendations fetched from a non-production storefront, just internal testing users.

## Magento release version

2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- Adobe Commerce only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- N/A

## Affected documentation pages


- https://docs.magento.com/user-guide/marketing/recommendation-change-source.html
