### PR TITLE
Add missing tab and notices for the Product Settings block

### DIFF
--- a/src/catalog/settings.md
+++ b/src/catalog/settings.md
@@ -15,6 +15,8 @@ _Product Settings_
 |[Sources]({% link catalog/sources.md %})|Lists the sources from which the product can be distributed.|
 |[Content]({% link catalog/product-content.md %})|Used to enter and edit the main product description that appears on the storefront product page.|
 |[Configurations]({% link catalog/product-configurations.md %})| Lists any existing variations of the product and can be used to generate variations for use with the Configurable product type.|
+|[Grouped Products]({% link catalog/product-create-grouped.md %})|Lists any existing variations of the product and can be used to generate variations for use with the Grouped product type.|
+|[Bundle Items]({% link catalog/product-bundle-items.md %})|Lists any existing variations of the product and can be used to generate variations for use with the Bundle product type.|
 |[Product Reviews]({% link catalog/settings-advanced-product-reviews.md %})|Lists all reviews that customers have submitted for the product.|
 |[Search Engine Optimization]({% link catalog/product-search-engine-optimization.md %})|Specifies the URL Key and metadata fields that are used by search engines to index the product.|
 |[Related Products, Up-Sells, and Cross-Sells]({% link catalog/related-products-up-sells-cross-sells.md %})|Used to set up simple promotional blocks on the storefront that present a selection of additional products that might be of interest to the customer.|
@@ -22,4 +24,5 @@ _Product Settings_
 |[Product in Websites]({% link catalog/settings-basic-websites.md %})| Identifies each website where the product is available, according to the store hierarchy.|
 |[Design]({% link catalog/settings-advanced-design.md %})|Used to apply a different theme to the product page, change the column layout, determine where product options appear, and enter custom XML code.|
 |[Gift options]({% link catalog/product-gift-options.md %})|Used to enable or disable a gift message option during checkout at the product level.|
-|[Downloadable Information]({% link catalog/product-downloadable-information.md %})|Used to generate the links to downloadable products and samples.|
+|{:.b2b-only}[Product In Shared Catalogs]({% link catalog/catalog-shared.md %})| Gives the ability to maintain gated shared catalogs with custom pricing for different companies and provides access to two types of shares catalogs with different pricing structures.|
+|[Downloadable Information]({% link catalog/product-downloadable-information.md %})|Used to generate the links to downloadable products and samples.This setting is only available for Simple, Virtual, and Downloadable product types.|

--- a/src/catalog/settings.md
+++ b/src/catalog/settings.md
@@ -24,5 +24,5 @@ _Product Settings_
 |[Product in Websites]({% link catalog/settings-basic-websites.md %})| Identifies each website where the product is available, according to the store hierarchy.|
 |[Design]({% link catalog/settings-advanced-design.md %})|Used to apply a different theme to the product page, change the column layout, determine where product options appear, and enter custom XML code.|
 |[Gift options]({% link catalog/product-gift-options.md %})|Used to enable or disable a gift message option during checkout at the product level.|
-|{:.b2b-only}[Product In Shared Catalogs]({% link catalog/catalog-shared.md %})| Gives the ability to maintain gated shared catalogs with custom pricing for different companies and provides access to two types of shares catalogs with different pricing structures.|
+|<span class="b2b-only">[Product In Shared Catalogs]({% link catalog/catalog-shared.md %})</span>| Enables the ability to maintain shared catalogs with custom pricing for different companies, with access to two types of shared catalogs using different pricing structures.|
 |[Downloadable Information]({% link catalog/product-downloadable-information.md %})|Used to generate the links to downloadable products and samples.This setting is only available for Simple, Virtual, and Downloadable product types.|


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) adds missing tab and notices for the Product Settings block

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- no

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- no

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/catalog/settings.html
