### PR TITLE
Fixed the link for Private Sales Report page

### DIFF
--- a/src/reports/reports-menu.md
+++ b/src/reports/reports-menu.md
@@ -42,7 +42,7 @@ The selection of [product reports]({% link reports/product-reports.md %}) includ
 {:.ee-only}
 ### Private Sales
 
-The selection of reports for [private sales and events]({% link reports/statistics.md %}) includes Invitation, Invited Customers, and Conversions.
+The selection of reports for [private sales and events]({% link reports/private-sales-reports.md %}) includes Invitation, Invited Customers, and Conversions.
 
 ### Statistics
 


### PR DESCRIPTION
## Purpose of this pull request

Fixed the link for Private Sales Report page. Previous link redirected a user to "Refresh Statistic" page instead of Private Sales Report page.

## Affected documentation pages

https://docs.magento.com/user-guide/reports/reports-menu.html