### PR TITLE
ACP2E-333: [Documentation] Mention that reward points in cart price rule are added once per each order

### DIFF
--- a/src/marketing/price-rules-cart-create.md
+++ b/src/marketing/price-rules-cart-create.md
@@ -211,7 +211,7 @@ The shopping cart price rule actions describe how prices are updated when the co
    |For matching items only |Free shipping is available only for items that match the conditions of the rule. |
    |For shipment with matching items |Free shipping is available for any shipment that includes matching item(s). |
 
-1. {:.ee-only}In the **Add Rewards Points** field, enter the number of points the customer earns whenever the cart price rule is applied. (If reward points are not enabled, leave this field blank.)
+1. {:.ee-only}In the **Add Rewards Points** field, enter the fixed number of points the customer earns **_once_** per each order whenever the cart price rule is applied. (If reward points are not enabled, leave this field blank.)
 
 1. When complete, click <span class="btn">Save and Continue Edit</span>.
 

--- a/src/marketing/price-rules-cart-create.md
+++ b/src/marketing/price-rules-cart-create.md
@@ -211,7 +211,7 @@ The shopping cart price rule actions describe how prices are updated when the co
    |For matching items only |Free shipping is available only for items that match the conditions of the rule. |
    |For shipment with matching items |Free shipping is available for any shipment that includes matching item(s). |
 
-1. {:.ee-only}In the **Add Rewards Points** field, enter the fixed number of points the customer earns **_once_** per each order whenever the cart price rule is applied. (If reward points are not enabled, leave this field blank.)
+1. {:.ee-only}In the **Add Rewards Points** field, enter the fixed number of points the customer earns **_once_** per order whenever the cart price rule is applied. (If reward points are not enabled, leave this field blank.)
 
 1. When complete, click <span class="btn">Save and Continue Edit</span>.
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

In scope of MC-42411 ticket investigation, it was found that current documentation should be updated to clarify that reward points in cart price rule are added once per each order.

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

Adobe Commerce only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

No

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

https://docs.magento.com/user-guide/marketing/price-rules-cart-create.html