### PR TITLE
ACP2E-338: [Documentation] Add notice that mini cart may be not synchronized across the multiple devices and browsers

### DIFF
--- a/src/sales/mini-cart.md
+++ b/src/sales/mini-cart.md
@@ -10,7 +10,7 @@ The mini cart displays a summary of items in the cart. It is enabled by default,
 _Mini Cart_
 
 {:.bs-callout-info}
-In some cases _registered_ customer Mini Cart may be not synchronized across the multiple devices and browsers automatically. To synchronize your Mini Cart in such cases, just open the [Shopping Cart]({% link sales/cart.md %}) page on that another device or browser.
+For a _registered_ customer, there are cases when the Mini Cart may not be synchronized across the multiple devices and browsers automatically. To synchronize the Mini Cart in such cases, the customer can simply open the [Shopping Cart]({% link sales/cart.md %}) page on that device or browser.
 
 ## Configure the mini cart
 

--- a/src/sales/mini-cart.md
+++ b/src/sales/mini-cart.md
@@ -9,6 +9,9 @@ The mini cart displays a summary of items in the cart. It is enabled by default,
 ![The shopper displays the shopping cart sidebar from a product page]({% link sales/assets/storefront-mini-cart-watch.png %}){: .zoom}
 _Mini Cart_
 
+{:.bs-callout-info}
+In some cases _registered_ customer Mini Cart may be not synchronized across the multiple devices and browsers automatically. To synchronize your Mini Cart in such cases, just open the [Shopping Cart]({% link sales/cart.md %}) page on that another device or browser.
+
 ## Configure the mini cart
 
 1. On the _Admin_ sidebar, go to **Stores** > _Settings_ > **Configuration**.


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

As a result of the Cache invalidation logic improvement for the customer section on Magento Cloud in scope of the MC-18191 ticket it was introduced following known acceptable Mini Cart drawback:
-In some cases registered customer Mini Cart may be not synchronized across the multiple devices and browsers automatically. To synchronize your registered customer Mini Cart in such cases, please open the Shopping Cart page on that another device or browser.

This information is described in the internal documentation:
https://wiki.corp.magento.com/pages/viewpage.action?spaceKey=MCP&title=Implementation+of+Cache+invalidation+logic+for+customer+section

So Merchants should be informed about such case and that this is an expected behavior in the external documentation as well:
https://docs.magento.com/user-guide/sales/mini-cart.html

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

Applicable to both Magento Open Source and Adobe Commerce

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

No

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

https://docs.magento.com/user-guide/sales/mini-cart.html