### PR TITLE
ACP2E-395: [Documentation] Add callout that to extend the customization of URLs new and existing URL Rewrites can be used

### DIFF
--- a/src/catalog/catalog-urls.md
+++ b/src/catalog/catalog-urls.md
@@ -27,6 +27,9 @@ The URL key is the part of a static URL that describes the product or category. 
 
 The URL key should consist of lowercase characters with hyphens to separate words. A well-designed, “search engine friendly” URL key might include the product name and key words to improve the way it is indexed by search engines. The URL key can be configured to create an automatic redirect if the URL key changes.
 
+{:.bs-callout-info}
+To extend the current URLs customization, such as localized URLs, new and existing [URL Rewrites]({% link marketing/url-rewrite.md %}) can be used.
+
 ### HTML suffix
 
 Your catalog can be configured to either include or exclude the suffix as part of category and product URLs. There are various reasons why people might choose to use or to omit the suffix. Some believe that the suffix no longer serves any useful purpose, and that pages without a suffix are indexed more effectively by search engines. However, your company might have a standardized format for URLs that requires a suffix.


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

According to the Product Owner's clarification and Developer investigation in the following ticket:

Add the following tip text:
`To extend the current URLs customization, such as localized URLs, new and existing [URL Rewrites]({% link marketing/url-rewrite.md %}) can be used.`

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

Applicable to both Magento Open Source and Adobe Commerce

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

No

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

https://docs.magento.com/user-guide/catalog/catalog-urls.html