### PR TITLE
ACP2E-424: [Documentation] Mention that product will have the same Allow permission in scope of all assigned categories in the Catalog

### DIFF
--- a/src/catalog/category-permissions.md
+++ b/src/catalog/category-permissions.md
@@ -125,3 +125,6 @@ Set this option to prevent members of a specific customer group from using Catal
 
 {:.bs-callout-info}
 If any product is assigned to the multiple number of categories, and it has any **_Allow_** permissions for at least one category, then it will have the same **_Allow_** permissions for all assigned categories automatically.
+
+{:.bs-callout-info}
+If any **_Allow_** permissions are set for the `Root Category`, then these permissions will be applied to all subcategories and all products in the `Catalog` automatically.

--- a/src/catalog/category-permissions.md
+++ b/src/catalog/category-permissions.md
@@ -122,3 +122,6 @@ Set this option to prevent members of a specific customer group from using Catal
    - Set the individual permissions as needed.
 
 1. When complete, click <span class="btn">Save</span>.
+
+{:.bs-callout-info}
+If any product is assigned to the multiple number of categories, and it has any **_Allow_** permissions for at least one category, then it will have the same **_Allow_** permissions for all assigned categories automatically.


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) is to mention that product will have the same Allow permission in scope of all assigned categories in the Catalog.
It was clarified in scope of ACP2E-416 and should be added to the Documentation.

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

Adobe Commerce only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

No

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

https://docs.magento.com/user-guide/catalog/category-permissions.html