### PR TITLE
Fix typo in page builder tutorial

### DIFF
--- a/src/cms/page-builder-tutorial1-simple-page.md
+++ b/src/cms/page-builder-tutorial1-simple-page.md
@@ -640,6 +640,6 @@ With all three rows complete, the final step is to rearrange the rows to match t
 
 **Congratulations!** You have completed Part 3 of the Simple Page tutorial. Keep the work that you created, so you can refer to it later.
 
-Wen you are ready, proceed to [Tutorial 2: Blocks]({% link cms/page-builder-tutorial2-blocks.md %})
+When you are ready, proceed to [Tutorial 2: Blocks]({% link cms/page-builder-tutorial2-blocks.md %})
 
 [1]: https://docs.magento.com/m2/downloads/simple-page-assets.zip


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) fixes a typo (*wen*) in the page builder tutorial

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/cms/page-builder-tutorial1-simple-page.html