### PR TITLE
ACP2E-436: [Documentation] Add clarification that all category permissions are set to Deny for all customer groups by Shared Catalog enabling

### DIFF
--- a/src/catalog/catalog-shared-category-permissions-update.md
+++ b/src/catalog/catalog-shared-category-permissions-update.md
@@ -6,8 +6,7 @@ title: Updating Category Permissions
 [Category permissions]({% link catalog/category-permissions.md %}) are automatically set to `Allow` for products that are added from the category tree to a shared catalog. You can later adjust the permissions, or create additional rules, as needed.
 
 {:.bs-callout-info}
-When the [Shared Catalog]({% link stores/b2b-features.md %}) B2B feature is enabled in the Configuration, each category permission, within the whole Catalog, will be set to `Deny` for all Customer Groups automatically.
-Additionally, each new category will have the same `Deny`category permissions by default to prevent showing this category on the Storefront website, before assignment to the Shared Catalog.
+When the [shared catalog]({% link stores/b2b-features.md %}) B2B feature is enabled in the configuration, each category permission for the catalog is set to `Deny` for all customer groups automatically. Additionally, when a new category is created, it has the `Deny` category permissions by default to prevent showing that category on the storefront site before assignment to the shared catalog.
 
 ## Update category permissions
 

--- a/src/catalog/catalog-shared-category-permissions-update.md
+++ b/src/catalog/catalog-shared-category-permissions-update.md
@@ -5,6 +5,10 @@ title: Updating Category Permissions
 
 [Category permissions]({% link catalog/category-permissions.md %}) are automatically set to `Allow` for products that are added from the category tree to a shared catalog. You can later adjust the permissions, or create additional rules, as needed.
 
+{:.bs-callout-info}
+When the [Shared Catalog]({% link stores/b2b-features.md %}) B2B feature is enabled in the Configuration, each category permission, within the whole Catalog, will be set to `Deny` for all Customer Groups automatically.
+Additionally, each new category will have the same `Deny`category permissions by default to prevent showing this category on the Storefront website, before assignment to the Shared Catalog.
+
 ## Update category permissions
 
 1. On the _Admin_ sidebar, go to **Catalog** > **Categories**.

--- a/src/catalog/catalog-shared.md
+++ b/src/catalog/catalog-shared.md
@@ -9,6 +9,10 @@ If the [Shared Catalog]({% link stores/b2b-features.md %}) feature is enabled in
 
 For the Default (General) public shared catalog, You must need to assign products to display catalog on the storefront. By default, it is empty and does not contain any products.
 
+{:.bs-callout-info}
+When the [Shared Catalog]({% link stores/b2b-features.md %}) B2B feature is enabled in the Configuration, each category permission, within the whole Catalog, will be set to `Deny` for all Customer Groups automatically.
+Additionally, each new category will have the same `Deny`category permissions by default to prevent showing this category on the Storefront website, before assignment to the Shared Catalog.
+
 The Shared Catalogs grid lists the shared catalogs that are currently in existence, and provides tools to create and maintain the catalogs.
 
 ![]({% link catalog/assets/shared-catalogs-grid.png %}){: .zoom}

--- a/src/catalog/catalog-shared.md
+++ b/src/catalog/catalog-shared.md
@@ -10,8 +10,7 @@ If the [Shared Catalog]({% link stores/b2b-features.md %}) feature is enabled in
 For the Default (General) public shared catalog, You must need to assign products to display catalog on the storefront. By default, it is empty and does not contain any products.
 
 {:.bs-callout-info}
-When the [Shared Catalog]({% link stores/b2b-features.md %}) B2B feature is enabled in the Configuration, each category permission, within the whole Catalog, will be set to `Deny` for all Customer Groups automatically.
-Additionally, each new category will have the same `Deny`category permissions by default to prevent showing this category on the Storefront website, before assignment to the Shared Catalog.
+When the [shared catalog]({% link stores/b2b-features.md %}) B2B feature is enabled in the configuration, each category permission for the catalog is set to `Deny` for all customer groups automatically. Additionally, when a new category is created, it has the `Deny` category permissions by default to prevent showing that category on the storefront site before assignment to the shared catalog.
 
 The Shared Catalogs grid lists the shared catalogs that are currently in existence, and provides tools to create and maintain the catalogs.
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) is to add clarification that all category permissions are set to Deny for all customer groups by B2B Shared Catalog enabling.

Product Owner clarification was given in scope of MC-35494 JIRA ticket:
https://jira.corp.magento.com/browse/MC-35494?focusedCommentId=1581403&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1581403

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

Adobe Commerce only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

B2B extension

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

https://docs.magento.com/user-guide/catalog/catalog-shared.html
https://docs.magento.com/user-guide/catalog/catalog-shared-category-permissions-update.html