### PR TITLE
ACP2E-460: [Documentation] Only images uploaded within the product description are managed by the new media gallery

### DIFF
--- a/src/cms/media-gallery.md
+++ b/src/cms/media-gallery.md
@@ -7,6 +7,10 @@ With Adobe Commerce or Magento Open Source 2.4, merchants can use the new _enhan
 ![Images displayed in the Media Gallery grid]({% link cms/assets/media-gallery-grid.png %}){: .zoom}
 _Media Gallery grid_
 
+{:.bs-callout-info}
+Product Gallery images from the `Images and Videos` product section are not managed by the New Media Gallery.
+Only images, which are used in the `Content` product section fields, are displayed and filtered in the New Media Gallery.
+
 ## Enable the new Media Gallery
 
 1. On the _Admin_ sidebar, go to **Stores** > _Settings_ > **Configuration**.

--- a/src/cms/media-gallery.md
+++ b/src/cms/media-gallery.md
@@ -8,8 +8,7 @@ With Adobe Commerce or Magento Open Source 2.4, merchants can use the new _enhan
 _Media Gallery grid_
 
 {:.bs-callout-info}
-Product Gallery images from the `Images and Videos` product section are not managed by the New Media Gallery.
-Only images, which are used in the `Content` product section fields, are displayed and filtered in the New Media Gallery.
+Product Gallery images added to the [_Images and Videos_ product section]({% linkcatalog/product-image-upload.md %}) are not managed by the New Media Gallery. Only images used in the _Content_ product section fields are displayed and filtered in the New Media Gallery.
 
 ## Enable the new Media Gallery
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) is to mention that Product Gallery images from the `Images and Videos` product section are not managed by the New Media Gallery. Only images, which are used in the `Content` product section fields, are displayed and filtered in the New Media Gallery.

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

Both Magento Open Source and Adobe Commerce

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

No

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

https://docs.magento.com/user-guide/cms/media-gallery.html