### PR TITLE
ACP2E-478: [Documentation] Add clarification of Purchase Order auto approval and manual approval cases

### DIFF
--- a/src/customers/account-dashboard-approval-rules.md
+++ b/src/customers/account-dashboard-approval-rules.md
@@ -64,7 +64,7 @@ _Creating a new approval rule_
    {:.bs-callout-info}
    * When assigning a role as an approver, ensure that there is at least one user in that role.
    * If there are at least two users having the same approver role, then creator of the Purchase Order cannot approve it. Manual approval is required by any other user having this approver role. However, if `Auto-approve POs created within this role` option is set in the Role Configuration, then this Purchase Order will be approved automatically.
-   * If there is only one user having approver role, then Purchase Order will be always approved automatically. And `Auto-approve POs created within this role` role configuration setting will be ignored in this case.
+   * If there is only one user having approver role, then Purchase Order will be always approved automatically. And `Auto-approve POs created within this role` configuration setting will be ignored in this case.
 
 1. Click <span class="btn">Save</span>.
 

--- a/src/customers/account-dashboard-approval-rules.md
+++ b/src/customers/account-dashboard-approval-rules.md
@@ -62,7 +62,9 @@ _Creating a new approval rule_
 1. For **Requires approval from** choose the required approver(s) according to the type of approval you want for the rule.
 
    {:.bs-callout-info}
-   When assigning a role as an approver, ensure that there is at least one user in that role.
+   * When assigning a role as an approver, ensure that there is at least one user in that role.
+   * If there are at least two users having the same approver role, then creator of the Purchase Order cannot approve it. Manual approval is required by any other user having this approver role. However, if `Auto-approve POs created within this role` option is set in the Role Configuration, then this Purchase Order will be approved automatically.
+   * If there is only one user having approver role, then Purchase Order will be always approved automatically. And `Auto-approve POs created within this role` role configuration setting will be ignored in this case.
 
 1. Click <span class="btn">Save</span>.
 

--- a/src/customers/account-dashboard-approval-rules.md
+++ b/src/customers/account-dashboard-approval-rules.md
@@ -63,8 +63,8 @@ _Creating a new approval rule_
 
    {:.bs-callout-info}
    * When assigning a role as an approver, ensure that there is at least one user in that role.
-   * If there are at least two users having the same approver role, then creator of the Purchase Order cannot approve it. Manual approval is required by any other user having this approver role. However, if `Auto-approve POs created within this role` option is set in the Role Configuration, then this Purchase Order will be approved automatically.
-   * If there is only one user having approver role, then Purchase Order will be always approved automatically. And `Auto-approve POs created within this role` configuration setting will be ignored in this case.
+   * If there are at least two users having the same approver role, then creator of the Purchase Order cannot approve it. Manual approval is required by any other user having this approver role. However, if `Auto-approve POs created within this role` option is set in the [Role Permissions]({% link customers/account-company-roles-permissions.md %}), then this Purchase Order will be approved automatically.
+   * If there is only one user having approver role, then Purchase Order will be always approved automatically. And `Auto-approve POs created within this role` permission setting will be ignored in this case.
 
 1. Click <span class="btn">Save</span>.
 


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

This pull request (PR) is to add clarification for Purchase Order auto approval and manual approval cases.
According to the B2B-589 User Story and Product Owner clarification in ACP2E-29:

Following text should be added:
* If there are two users having the same approver role, then creator of the Purchase Order cannot approve it. And manual approval is required by any other user of this approver role. However, if "Auto-approve POs created within this role" option is set in the Role Configuration, then this Purchase Order will be approved automatically.
* If there is only one user having approver role, then Purchase Order will be always approved automatically. And "Auto-approve POs created within this role" Role Configuration option will be ignored in this case.

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

- Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- Adobe Commerce only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- B2B

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/customers/account-dashboard-approval-rules.html