### PR TITLE
Include store_id in default customer attributes list

### DIFF
--- a/src/stores/attributes-customer.md
+++ b/src/stores/attributes-customer.md
@@ -145,6 +145,7 @@ Attribute Code  | Description
 `created_at`    | The date the customer account was created.
 `updated_at`    | The date the customer account was last updated.
 `website_id`    | The website ID of the site where the customer account was created.
+`store_id`      | The store ID of the site where the customer account was created.
 `created_in`    | The store view where the account was created.
 `group_id`      | The ID of the customer group where the customer is assigned.
 `disable_auto_group_change` | Determines if customer groups can be dynamically assigned during [VAT ID validation]({% link tax/vat-validation.md %}).


### PR DESCRIPTION
## Purpose of this pull request

It looks like  customer attribute with attribute_code = `store_id` is included in default customer attributes provided by magento but it's not in the doc's list.

## Magento release version

2.3.x, 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- Adobe Commerce only

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- No

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://docs.magento.com/user-guide/stores/attributes-customer.html#default-customer-attributes
